### PR TITLE
Add code coverage to CI

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -31,8 +31,8 @@ jobs:
     displayName: 'Install dependencies'
 
   - script: |
-      pip install pytest pytest-azurepipelines
-      pytest --verbose
+      pip install pytest pytest-azurepipelines pytest-cov
+      pytest --verbose --cov=./ --cov-report=xml
     displayName: 'pytest'
 
   - script: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -36,8 +36,8 @@ jobs:
     displayName: 'pytest'
 
   - bash: |
-    curl https://codecov.io/bash > codecov.sh
-    bash codecov.sh -t aba016f6-96be-4bc3-bdbe-caa6b6aff815
+      curl https://codecov.io/bash > codecov.sh
+      bash codecov.sh -t aba016f6-96be-4bc3-bdbe-caa6b6aff815
     displayName: 'Upload coverage to codecov.io'
 
 - job: LintFlake8

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -35,7 +35,7 @@ jobs:
       pytest --verbose
     displayName: 'pytest'
 
-  - bash: |
+  - script: |
       curl https://codecov.io/bash > codecov.sh
       bash codecov.sh -t aba016f6-96be-4bc3-bdbe-caa6b6aff815
     displayName: 'Upload coverage to codecov.io'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -35,6 +35,11 @@ jobs:
       pytest --verbose
     displayName: 'pytest'
 
+  - bash: |
+    curl https://codecov.io/bash > codecov.sh
+    bash codecov.sh -t aba016f6-96be-4bc3-bdbe-caa6b6aff815
+    displayName: 'Upload coverage to codecov.io'
+
 - job: LintFlake8
   pool:
     vmImage: 'ubuntu-16.04'

--- a/test.txt
+++ b/test.txt
@@ -1,0 +1,1 @@
+Something in here

--- a/test.txt
+++ b/test.txt
@@ -1,1 +1,0 @@
-Something in here


### PR DESCRIPTION
@keewis [pointed out](https://github.com/xarray-contrib/pint-xarray/pull/11#issuecomment-655632247) that after moving to xarray-contrib we seem to have lost the CI. I've re-created the Azure pipeline that's supposed to run the CI tests (including pytest and black), which I have been able to re-run on master. I want to check it's working on new PRs.