### PR TITLE
rewrite quantify and dequantify

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -21,7 +21,7 @@ DataArray
 ---------
 .. autosummary::
    :toctree: generated/
-   :template: autosummary/accessor_property.rst
+   :template: autosummary/accessor_attribute.rst
 
    DataArray.pint.magnitude
    DataArray.pint.units

--- a/pint_xarray/accessors.py
+++ b/pint_xarray/accessors.py
@@ -150,7 +150,7 @@ class PintDataArrayAccessor:
             Unit registry to be used for the units attached to this DataArray.
             If not given then a default registry will be created.
         registry_kwargs : dict, optional
-            Keyword arguments to be passed to `pint.UnitRegistry`.
+            Keyword arguments to be passed to :py:class:`pint.UnitRegistry`.
         **unit_kwargs
             Keyword argument form of units.
 
@@ -208,7 +208,7 @@ class PintDataArrayAccessor:
         Removes units from the DataArray and its coordinates.
 
         Will replace ``.attrs['units']`` on each variable with a string
-        representation of the `pint.Unit` instance.
+        representation of the :py:class:`pint.Unit` instance.
 
         Returns
         -------
@@ -259,7 +259,7 @@ class PintDataArrayAccessor:
         ----------
         units : str or pint.Unit or mapping of hashable to str or pint.Unit, optional
             The units to convert to. If a unit name or
-            :py:class`pint.Unit` object, convert the DataArray's
+            :py:class:`pint.Unit` object, convert the DataArray's
             data. If a dict-like, it has to map a variable name to a
             unit name or :py:class:`pint.Unit` object.
         **unit_kwargs
@@ -415,10 +415,11 @@ class PintDatasetAccessor:
         ----------
         units : mapping of hashable to pint.Unit or str, optional
             Physical units to use for particular DataArrays in this
-            Dataset. It should map variable names to units. If not
-            provided, will try to read them from
-            ``Dataset[var].attrs['units']`` using pint's parser.
-        unit_registry : `pint.UnitRegistry`, optional
+            Dataset. It should map variable names to units (unit names
+            or ``pint.Unit`` objects). If not provided, will try to
+            read them from ``Dataset[var].attrs['units']`` using
+            pint's parser.
+        unit_registry : pint.UnitRegistry, optional
             Unit registry to be used for the units attached to each
             DataArray in this Dataset. If not given then a default
             registry will be created.

--- a/pint_xarray/accessors.py
+++ b/pint_xarray/accessors.py
@@ -140,8 +140,12 @@ class PintDataArrayAccessor:
         Parameters
         ----------
         units : pint.Unit or str or mapping of hashable to pint.Unit or str, optional
-            Physical units to use for this DataArray: . If not provided, will try
-            to read them from ``DataArray.attrs['units']`` using pint's parser.
+            Physical units to use for this DataArray. If a str or
+            pint.Unit, will be used as the DataArray's units. If a
+            dict-like, it should map a variable name to the desired
+            unit (use the DataArray's name to refer to its data). If
+            not provided, will try to read them from
+            ``DataArray.attrs['units']`` using pint's parser.
         unit_registry : pint.UnitRegistry, optional
             Unit registry to be used for the units attached to this DataArray.
             If not given then a default registry will be created.
@@ -411,12 +415,13 @@ class PintDatasetAccessor:
         ----------
         units : mapping of hashable to pint.Unit or str, optional
             Physical units to use for particular DataArrays in this
-            Dataset. If not provided, will try to read them from
+            Dataset. It should map variable names to units. If not
+            provided, will try to read them from
             ``Dataset[var].attrs['units']`` using pint's parser.
         unit_registry : `pint.UnitRegistry`, optional
-            Unit registry to be used for the units attached to each DataArray
-            in this Dataset. If not given then a default registry will be
-            created.
+            Unit registry to be used for the units attached to each
+            DataArray in this Dataset. If not given then a default
+            registry will be created.
         registry_kwargs : dict, optional
             Keyword arguments to be passed to `pint.UnitRegistry`.
         **unit_kwargs

--- a/pint_xarray/accessors.py
+++ b/pint_xarray/accessors.py
@@ -1,4 +1,6 @@
 # TODO is it possible to import pint-xarray from within xarray if pint is present?
+import itertools
+
 import numpy as np
 import pint
 from pint.quantity import Quantity
@@ -33,6 +35,33 @@ if not IS_NEP18_ACTIVE:
 
 def is_dict_like(obj):
     return hasattr(obj, "keys") and hasattr(obj, "__getitem__")
+
+
+def zip_mappings(*mappings, fill_value=None):
+    """ zip mappings by combining values for common keys into a tuple
+
+    Works like itertools.zip_longest, so if a key is missing from a
+    mapping, it is replaced by ``fill_value``.
+
+    Parameters
+    ----------
+    *mappings : dict-like
+        The mappings to zip
+    fill_value
+        The value to use if a key is missing from a mapping.
+
+    Returns
+    -------
+    zipped : dict-like
+        The zipped mapping
+    """
+    keys = set(itertools.chain.from_iterable(mapping.keys() for mapping in mappings))
+
+    # TODO: could this be made more efficient using itertools.groupby?
+    zipped = {
+        key: tuple(mapping.get(key, fill_value) for mapping in mappings) for key in keys
+    }
+    return zipped
 
 
 # based on xarray.core.utils.either_dict_or_kwargs

--- a/pint_xarray/accessors.py
+++ b/pint_xarray/accessors.py
@@ -256,20 +256,12 @@ class PintDataArrayAccessor:
         that was previously wrapped by `pint.Quantity`.
         """
 
-        if not isinstance(self.da.data, Quantity):
-            raise ValueError(
-                "Cannot remove units from data that does not have" " units"
-            )
-
-        # TODO also dequantify coords (once explicit indexes ready)
-        da = DataArray(
-            dims=self.da.dims,
-            data=self.da.pint.magnitude,
-            coords=self.da.coords,
-            attrs=self.da.attrs,
+        units = conversion.extract_units(self.da)
+        new_obj = conversion.attach_unit_attributes(
+            conversion.strip_units(self.da), units,
         )
-        da.attrs["units"] = str(self.da.data.units)
-        return da
+
+        return new_obj
 
     @property
     def magnitude(self):

--- a/pint_xarray/accessors.py
+++ b/pint_xarray/accessors.py
@@ -194,14 +194,12 @@ class PintDataArrayAccessor:
             unit_kwargs[self.da.name] = units
             units = None
 
-        # don't modify the original object
-        new_obj = self.da.copy()
-
         units = either_dict_or_kwargs(units, unit_kwargs, ".quantify")
 
         registry = _get_registry(unit_registry, registry_kwargs)
 
-        unit_attrs = conversion.extract_unit_attributes(new_obj, delete=True)
+        unit_attrs = conversion.extract_unit_attributes(self.da)
+        new_obj = conversion.strip_unit_attributes(self.da)
 
         units = {
             name: _decide_units(unit, registry, unit_attribute)
@@ -479,13 +477,12 @@ class PintDatasetAccessor:
             a        (x) int64 <Quantity([0 3 2], 'meter')>
             b        (x) int64 <Quantity([ 5 -2  1], 'decimeter')>
         """
-        # don't modify the original object
-        new_obj = self.ds.copy()
-
         units = either_dict_or_kwargs(units, unit_kwargs, ".quantify")
         registry = _get_registry(unit_registry, registry_kwargs)
 
-        unit_attrs = conversion.extract_unit_attributes(new_obj, delete=True)
+        unit_attrs = conversion.extract_unit_attributes(self.ds)
+        new_obj = conversion.strip_unit_attributes(self.ds)
+
         units = {
             name: _decide_units(unit, registry, attr)
             for name, (unit, attr) in zip_mappings(units, unit_attrs).items()

--- a/pint_xarray/accessors.py
+++ b/pint_xarray/accessors.py
@@ -154,7 +154,9 @@ class PintDataArrayAccessor:
             dict-like, it should map a variable name to the desired
             unit (use the DataArray's name to refer to its data). If
             not provided, will try to read them from
-            ``DataArray.attrs['units']`` using pint's parser.
+            ``DataArray.attrs['units']`` using pint's parser. The
+            ``"units"`` attribute will be removed from all variables
+            except from dimension coordinates.
         unit_registry : pint.UnitRegistry, optional
             Unit registry to be used for the units attached to this DataArray.
             If not given then a default registry will be created.
@@ -167,8 +169,7 @@ class PintDataArrayAccessor:
         -------
         quantified : DataArray
             DataArray whose wrapped array data will now be a Quantity
-            array with the specified units. Any ``"units"`` attributes
-            will be removed except for dimension coordinates.
+            array with the specified units.
 
         Examples
         --------
@@ -275,10 +276,10 @@ class PintDataArrayAccessor:
         Parameters
         ----------
         units : str or pint.Unit or mapping of hashable to str or pint.Unit, optional
-            The units to convert to. If a unit name or
-            ``pint.Unit`` object, convert the DataArray's
-            data. If a dict-like, it has to map a variable name to a
-            unit name or ``pint.Unit`` object.
+            The units to convert to. If a unit name or ``pint.Unit``
+            object, convert the DataArray's data. If a dict-like, it
+            has to map a variable name to a unit name or ``pint.Unit``
+            object.
         **unit_kwargs
             The kwargs form of ``units``. Can only be used for
             variable names that are strings and valid python identifiers.
@@ -444,7 +445,8 @@ class PintDatasetAccessor:
             Dataset. It should map variable names to units (unit names
             or ``pint.Unit`` objects). If not provided, will try to
             read them from ``Dataset[var].attrs['units']`` using
-            pint's parser.
+            pint's parser. The ``"units"`` attribute will be removed
+            from all variables except from dimension coordinates.
         unit_registry : pint.UnitRegistry, optional
             Unit registry to be used for the units attached to each
             DataArray in this Dataset. If not given then a default
@@ -458,8 +460,7 @@ class PintDatasetAccessor:
         -------
         quantified : Dataset
             Dataset whose variables will now contain Quantity arrays
-            with units. Any ``"units"`` attributes will be removed
-            except from dimension coordinates.
+            with units.
 
         Examples
         --------

--- a/pint_xarray/accessors.py
+++ b/pint_xarray/accessors.py
@@ -64,6 +64,13 @@ def zip_mappings(*mappings, fill_value=None):
     return zipped
 
 
+def units_to_str_or_none(mapping):
+    return {
+        key: str(value) if isinstance(value, Unit) else value
+        for key, value in mapping.items()
+    }
+
+
 # based on xarray.core.utils.either_dict_or_kwargs
 # https://github.com/pydata/xarray/blob/v0.15.1/xarray/core/utils.py#L249-L268
 def either_dict_or_kwargs(positional, keywords, method_name):
@@ -257,10 +264,7 @@ class PintDataArrayAccessor:
             that was previously wrapped by `pint.Quantity`.
         """
 
-        units = {
-            key: str(value) if isinstance(value, pint.Unit) else value
-            for key, value in conversion.extract_units(self.da).items()
-        }
+        units = units_to_str_or_none(conversion.extract_units(self.da))
         new_obj = conversion.attach_unit_attributes(
             conversion.strip_units(self.da), units,
         )
@@ -485,8 +489,10 @@ class PintDatasetAccessor:
         return conversion.attach_units(self.ds, units)
 
     def dequantify(self):
-        units = conversion.extract_units(self.ds)
-        new_obj = conversion.attach_units(conversion.strip_units(self.ds), units)
+        units = units_to_str_or_none(conversion.extract_units(self.ds))
+        new_obj = conversion.attach_unit_attributes(
+            conversion.strip_units(self.ds), units
+        )
         return new_obj
 
     def to(self, units=None, **unit_kwargs):

--- a/pint_xarray/accessors.py
+++ b/pint_xarray/accessors.py
@@ -189,8 +189,7 @@ class PintDataArrayAccessor:
 
         registry = _get_registry(unit_registry, registry_kwargs)
 
-        # TODO should we (temporarily) remove the attrs here so that they don't become inconsistent?
-        unit_attrs = conversion.extract_unit_attributes(self.da, delete=False)
+        unit_attrs = conversion.extract_unit_attributes(self.da, delete=True)
 
         units = {
             name: _decide_units(unit, registry, unit_attribute)
@@ -458,8 +457,7 @@ class PintDatasetAccessor:
         units = either_dict_or_kwargs(units, unit_kwargs, ".quantify")
         registry = _get_registry(unit_registry, registry_kwargs)
 
-        # TODO should we (temporarily) remove the attrs here so that they don't become inconsistent?
-        unit_attrs = conversion.extract_unit_attributes(self.ds, delete=False)
+        unit_attrs = conversion.extract_unit_attributes(self.ds, delete=True)
         units = {
             name: _decide_units(unit, registry, attr)
             for name, (unit, attr) in zip_mappings(units, unit_attrs).items()

--- a/pint_xarray/accessors.py
+++ b/pint_xarray/accessors.py
@@ -142,6 +142,10 @@ class PintDataArrayAccessor:
             the data into memory. To avoid that, consider converting
             to ``dask`` first (e.g. using ``chunk``).
 
+            As units in dimension coordinates are not supported until
+            ``xarray`` changes the way it implements indexes, these
+            units will be set as attributes.
+
         Parameters
         ----------
         units : pint.Unit or str or mapping of hashable to pint.Unit or str, optional
@@ -163,7 +167,8 @@ class PintDataArrayAccessor:
         -------
         quantified : DataArray
             DataArray whose wrapped array data will now be a Quantity
-            array with the specified units.
+            array with the specified units. Any ``"units"`` attributes
+            will be removed except for dimension coordinates.
 
         Examples
         --------
@@ -172,7 +177,7 @@ class PintDataArrayAccessor:
         ...     dims="frequency",
         ...     coords={"wavelength": [1e-4, 2e-4, 4e-4, 6e-4, 1e-3, 2e-3]},
         ... )
-        >>> da.pint.quantify(units='Hz')
+        >>> da.pint.quantify(units="Hz")
         <xarray.DataArray (frequency: 6)>
         Quantity([ 0.4,  0.9,  1.7,  4.8,  3.2,  9.1], 'Hz')
         Coordinates:
@@ -428,6 +433,10 @@ class PintDatasetAccessor:
             the data into memory. To avoid that, consider converting
             to ``dask`` first (e.g. using ``chunk``).
 
+            As units in dimension coordinates are not supported until
+            ``xarray`` changes the way it implements indexes, these
+            units will be set as attributes.
+
         Parameters
         ----------
         units : mapping of hashable to pint.Unit or str, optional
@@ -449,7 +458,8 @@ class PintDatasetAccessor:
         -------
         quantified : Dataset
             Dataset whose variables will now contain Quantity arrays
-            with units.
+            with units. Any ``"units"`` attributes will be removed
+            except from dimension coordinates.
 
         Examples
         --------

--- a/pint_xarray/accessors.py
+++ b/pint_xarray/accessors.py
@@ -257,7 +257,10 @@ class PintDataArrayAccessor:
             that was previously wrapped by `pint.Quantity`.
         """
 
-        units = conversion.extract_units(self.da)
+        units = {
+            key: str(value) if isinstance(value, pint.Unit) else value
+            for key, value in conversion.extract_units(self.da).items()
+        }
         new_obj = conversion.attach_unit_attributes(
             conversion.strip_units(self.da), units,
         )

--- a/pint_xarray/accessors.py
+++ b/pint_xarray/accessors.py
@@ -150,7 +150,7 @@ class PintDataArrayAccessor:
             Unit registry to be used for the units attached to this DataArray.
             If not given then a default registry will be created.
         registry_kwargs : dict, optional
-            Keyword arguments to be passed to :py:class:`pint.UnitRegistry`.
+            Keyword arguments to be passed to the unit registry.
         **unit_kwargs
             Keyword argument form of units.
 
@@ -208,7 +208,7 @@ class PintDataArrayAccessor:
         Removes units from the DataArray and its coordinates.
 
         Will replace ``.attrs['units']`` on each variable with a string
-        representation of the :py:class:`pint.Unit` instance.
+        representation of the ``pint.Unit`` instance.
 
         Returns
         -------
@@ -259,9 +259,9 @@ class PintDataArrayAccessor:
         ----------
         units : str or pint.Unit or mapping of hashable to str or pint.Unit, optional
             The units to convert to. If a unit name or
-            :py:class:`pint.Unit` object, convert the DataArray's
+            ``pint.Unit`` object, convert the DataArray's
             data. If a dict-like, it has to map a variable name to a
-            unit name or :py:class:`pint.Unit` object.
+            unit name or ``pint.Unit`` object.
         **unit_kwargs
             The kwargs form of ``units``. Can only be used for
             variable names that are strings and valid python identifiers.
@@ -404,7 +404,7 @@ class PintDatasetAccessor:
         """
         Attaches units to each variable in the Dataset.
 
-        Units can be specified as a :py:class:`pint.Unit` or as a
+        Units can be specified as a ``pint.Unit`` or as a
         string, which will be parsed by the given unit registry. If no
         units are specified then the units will be parsed from the
         ``"units"`` entry of the Dataset variable's ``.attrs``. Will
@@ -477,13 +477,13 @@ class PintDatasetAccessor:
         Removes units from the Dataset and its coordinates.
 
         Will replace ``.attrs['units']`` on each variable with a string
-        representation of the :py:class:`pint.Unit` instance.
+        representation of the ``pint.Unit`` instance.
 
         Returns
         -------
         dequantified : Dataset
             Dataset whose data variables are unitless, and of the type
-            that was previously wrapped by :py:class:`pint.Quantity`.
+            that was previously wrapped by ``pint.Quantity``.
         """
         units = units_to_str_or_none(conversion.extract_units(self.ds))
         new_obj = conversion.attach_unit_attributes(

--- a/pint_xarray/accessors.py
+++ b/pint_xarray/accessors.py
@@ -136,10 +136,10 @@ def _get_registry(unit_registry, registry_kwargs):
 
 
 def _decide_units(units, registry, unit_attribute):
-    if not units and not unit_attribute:
+    if units is None and unit_attribute is None:
         # or warn and return None?
         raise ValueError("no units given")
-    elif not units:
+    elif units is None:
         # TODO option to read and decode units according to CF conventions (see MetPy)?
         units = registry.parse_expression(unit_attribute).units
     elif isinstance(units, Unit):

--- a/pint_xarray/accessors.py
+++ b/pint_xarray/accessors.py
@@ -137,6 +137,11 @@ class PintDataArrayAccessor:
         `.attrs`. Will raise a ValueError if the DataArray already contains a
         unit-aware array.
 
+        .. note::
+            Be aware that unless you're using ``dask`` this will load
+            the data into memory. To avoid that, consider converting
+            to ``dask`` first (e.g. using ``chunk``).
+
         Parameters
         ----------
         units : pint.Unit or str or mapping of hashable to pint.Unit or str, optional
@@ -410,6 +415,11 @@ class PintDatasetAccessor:
         ``"units"`` entry of the Dataset variable's ``.attrs``. Will
         raise a ValueError if any of the variables already contain a
         unit-aware array.
+
+        .. note::
+            Be aware that unless you're using ``dask`` this will load
+            the data into memory. To avoid that, consider converting
+            to ``dask`` first (e.g. using ``chunk``).
 
         Parameters
         ----------

--- a/pint_xarray/accessors.py
+++ b/pint_xarray/accessors.py
@@ -252,9 +252,9 @@ class PintDataArrayAccessor:
 
     def dequantify(self):
         """
-        Removes units from the DataArray and it's coordinates.
+        Removes units from the DataArray and its coordinates.
 
-        Will replace `.attrs['units']` on each variable with a string
+        Will replace ``.attrs['units']`` on each variable with a string
         representation of the `pint.Unit` instance.
 
         Returns
@@ -489,6 +489,18 @@ class PintDatasetAccessor:
         return conversion.attach_units(self.ds, units)
 
     def dequantify(self):
+        """
+        Removes units from the Dataset and its coordinates.
+
+        Will replace ``.attrs['units']`` on each variable with a string
+        representation of the :py:class:`pint.Unit` instance.
+
+        Returns
+        -------
+        dequantified : Dataset
+            Dataset whose data variables are unitless, and of the type
+            that was previously wrapped by :py:class:`pint.Quantity`.
+        """
         units = units_to_str_or_none(conversion.extract_units(self.ds))
         new_obj = conversion.attach_unit_attributes(
             conversion.strip_units(self.ds), units

--- a/pint_xarray/accessors.py
+++ b/pint_xarray/accessors.py
@@ -252,8 +252,9 @@ class PintDataArrayAccessor:
 
         Returns
         -------
-        dequantified - DataArray whose array data is unitless, and of the type
-        that was previously wrapped by `pint.Quantity`.
+        dequantified : DataArray
+            DataArray whose array data is unitless, and of the type
+            that was previously wrapped by `pint.Quantity`.
         """
 
         units = conversion.extract_units(self.da)

--- a/pint_xarray/accessors.py
+++ b/pint_xarray/accessors.py
@@ -467,7 +467,7 @@ class PintDatasetAccessor:
 
         Parameters
         ----------
-        units : mapping from variable names to pint.Unit or str, optional
+        units : mapping of hashable to pint.Unit or str, optional
             Physical units to use for particular DataArrays in this
             Dataset. If not provided, will try to read them from
             ``Dataset[var].attrs['units']`` using pint's parser.

--- a/pint_xarray/conversion.py
+++ b/pint_xarray/conversion.py
@@ -1,3 +1,5 @@
+import itertools
+
 import pint
 from xarray import DataArray, Dataset, Variable
 
@@ -192,6 +194,24 @@ def extract_units(obj):
         units = {**vars_units}
     else:
         raise ValueError(f"unknown type: {type(obj)}")
+
+    return units
+
+
+def extract_unit_attributes(obj, delete=False):
+    method = dict.pop if delete else dict.get
+    if isinstance(obj, DataArray):
+        variables = itertools.chain([(obj.name, obj)], obj.coords.items(),)
+        units = {name: method(var.attrs, "units", None) for name, var in variables}
+    elif isinstance(obj, Dataset):
+        units = {
+            name: method(var.attrs, "units", None)
+            for name, var in obj.variables.items()
+        }
+    else:
+        raise ValueError(
+            f"cannot retrieve unit attributes from unknown type: {type(obj)}"
+        )
 
     return units
 

--- a/pint_xarray/conversion.py
+++ b/pint_xarray/conversion.py
@@ -222,18 +222,17 @@ def extract_units(obj):
     return units
 
 
-def extract_unit_attributes(obj, delete=False):
+def extract_unit_attributes(obj, delete=False, attr="units"):
     method = dict.pop if delete else dict.get
     if isinstance(obj, DataArray):
         variables = itertools.chain([(obj.name, obj)], obj.coords.items())
-        units = {name: method(var.attrs, "units", None) for name, var in variables}
+        units = {name: method(var.attrs, attr, None) for name, var in variables}
     elif isinstance(obj, Dataset):
         units = {
-            name: method(var.attrs, "units", None)
-            for name, var in obj.variables.items()
+            name: method(var.attrs, attr, None) for name, var in obj.variables.items()
         }
     elif isinstance(obj, Variable):
-        units = {None: method(obj.attrs, "units", None)}
+        units = {None: method(obj.attrs, attr, None)}
     else:
         raise ValueError(
             f"cannot retrieve unit attributes from unknown type: {type(obj)}"

--- a/pint_xarray/conversion.py
+++ b/pint_xarray/conversion.py
@@ -232,6 +232,8 @@ def extract_unit_attributes(obj, delete=False):
             name: method(var.attrs, "units", None)
             for name, var in obj.variables.items()
         }
+    elif isinstance(obj, Variable):
+        units = {None: method(obj.attrs, "units", None)}
     else:
         raise ValueError(
             f"cannot retrieve unit attributes from unknown type: {type(obj)}"

--- a/pint_xarray/tests/test_accessors.py
+++ b/pint_xarray/tests/test_accessors.py
@@ -4,7 +4,7 @@ import xarray as xr
 from numpy.testing import assert_array_equal
 from pint import Unit, UnitRegistry
 from pint.errors import UndefinedUnitError
-from xarray.testing import assert_equal
+from xarray.testing import assert_equal, assert_identical
 
 from .. import conversion
 from .utils import raises_regex
@@ -55,11 +55,14 @@ def example_quantity_da():
 
 class TestQuantifyDataArray:
     def test_attach_units_from_str(self, example_unitless_da):
-        orig = example_unitless_da
-        result = orig.pint.quantify("m")
+        obj = example_unitless_da
+        orig = obj.copy()
+
+        result = obj.pint.quantify("m")
         assert_array_equal(result.data.magnitude, orig.data)
         # TODO better comparisons for when you can't access the unit_registry?
         assert str(result.data.units) == "meter"
+        assert_identical(orig, obj)
 
     def test_attach_units_given_registry(self, example_unitless_da):
         orig = example_unitless_da
@@ -167,10 +170,12 @@ class TestUncertainties:
 
 class TestQuantifyDataSet:
     def test_attach_units_from_str(self, example_unitless_ds):
-        orig = example_unitless_ds
-        result = orig.pint.quantify()
+        obj = example_unitless_ds
+        orig = obj.copy()
+        result = obj.pint.quantify()
         assert_array_equal(result["users"].data.magnitude, orig["users"].data)
         assert str(result["users"].data.units) == "dimensionless"
+        assert_identical(orig, obj)
 
     def test_attach_units_given_registry(self, example_unitless_ds):
         orig = example_unitless_ds

--- a/pint_xarray/tests/test_accessors.py
+++ b/pint_xarray/tests/test_accessors.py
@@ -4,7 +4,7 @@ import xarray as xr
 from numpy.testing import assert_array_equal
 from pint import Unit, UnitRegistry
 from pint.errors import UndefinedUnitError
-from xarray.testing import assert_equal, assert_identical
+from xarray.testing import assert_equal
 
 from .. import conversion
 from .utils import raises_regex
@@ -55,14 +55,11 @@ def example_quantity_da():
 
 class TestQuantifyDataArray:
     def test_attach_units_from_str(self, example_unitless_da):
-        obj = example_unitless_da
-        orig = obj.copy()
-
-        result = obj.pint.quantify("m")
+        orig = example_unitless_da
+        result = orig.pint.quantify("m")
         assert_array_equal(result.data.magnitude, orig.data)
         # TODO better comparisons for when you can't access the unit_registry?
         assert str(result.data.units) == "meter"
-        assert_identical(orig, obj)
 
     def test_attach_units_given_registry(self, example_unitless_da):
         orig = example_unitless_da
@@ -170,12 +167,10 @@ class TestUncertainties:
 
 class TestQuantifyDataSet:
     def test_attach_units_from_str(self, example_unitless_ds):
-        obj = example_unitless_ds
-        orig = obj.copy()
-        result = obj.pint.quantify()
+        orig = example_unitless_ds
+        result = orig.pint.quantify()
         assert_array_equal(result["users"].data.magnitude, orig["users"].data)
         assert str(result["users"].data.units) == "dimensionless"
-        assert_identical(orig, obj)
 
     def test_attach_units_given_registry(self, example_unitless_ds):
         orig = example_unitless_ds

--- a/pint_xarray/tests/test_accessors.py
+++ b/pint_xarray/tests/test_accessors.py
@@ -74,6 +74,9 @@ class TestQuantifyDataArray:
         assert_array_equal(result.data.magnitude, orig.data)
         assert str(result.data.units) == "meter"
 
+        remaining_attrs = conversion.extract_unit_attributes(result)
+        assert {k: v for k, v in remaining_attrs.items() if v is not None} == {}
+
     def test_attach_units_given_unit_objs(self, example_unitless_da):
         orig = example_unitless_da
         ureg = UnitRegistry(force_ndarray=True)
@@ -184,6 +187,9 @@ class TestQuantifyDataSet:
         result = orig.pint.quantify({"users": "dimensionless"})
         assert_array_equal(result["users"].data.magnitude, orig["users"].data)
         assert str(result["users"].data.units) == "dimensionless"
+
+        remaining_attrs = conversion.extract_unit_attributes(result)
+        assert {k: v for k, v in remaining_attrs.items() if v is not None} == {}
 
     def test_attach_units_given_unit_objs(self, example_unitless_ds):
         orig = example_unitless_ds

--- a/pint_xarray/tests/test_accessors.py
+++ b/pint_xarray/tests/test_accessors.py
@@ -26,7 +26,7 @@ def example_unitless_da():
     da = xr.DataArray(
         data=array,
         dims="x",
-        coords={"x": ("x", x, {"units": "s"}), "u": ("x", u, {"units": "hour"})},
+        coords={"x": ("x", x), "u": ("x", u, {"units": "hour"})},
         attrs={"units": "m"},
     )
     return da
@@ -37,9 +37,7 @@ def example_quantity_da():
     array = np.linspace(0, 10, 20) * unit_registry.m
     x = np.arange(20)
     u = np.linspace(0, 1, 20) * unit_registry.hour
-    return xr.DataArray(
-        data=array, dims="x", coords={"x": ("x", x, {"units": "s"}), "u": ("x", u)},
-    )
+    return xr.DataArray(data=array, dims="x", coords={"x": ("x", x), "u": ("x", u)})
 
 
 class TestQuantifyDataArray:

--- a/pint_xarray/tests/test_accessors.py
+++ b/pint_xarray/tests/test_accessors.py
@@ -92,10 +92,6 @@ class TestDequantifyDataArray:
         assert isinstance(result.data, np.ndarray)
         assert isinstance(result.coords["x"].data, np.ndarray)
 
-    def test_error_if_no_units(self, example_unitless_da):
-        with raises_regex(ValueError, "does not have units"):
-            example_unitless_da.pint.dequantify()
-
     def test_attrs_reinstated(self, example_quantity_da):
         da = example_quantity_da
         result = da.pint.dequantify()

--- a/pint_xarray/tests/test_accessors.py
+++ b/pint_xarray/tests/test_accessors.py
@@ -8,27 +8,38 @@ from xarray.testing import assert_equal
 
 from .utils import raises_regex
 
+pytestmark = [
+    pytest.mark.filterwarnings("error::pint.UnitStrippedWarning"),
+]
+
 # make sure scalars are converted to 0d arrays so quantities can
 # always be treated like ndarrays
 unit_registry = UnitRegistry(force_ndarray=True)
 Quantity = unit_registry.Quantity
 
 
-@pytest.fixture()
+@pytest.fixture
 def example_unitless_da():
     array = np.linspace(0, 10, 20)
     x = np.arange(20)
-    da = xr.DataArray(data=array, dims="x", coords={"x": x})
-    da.attrs["units"] = "m"
-    da.coords["x"].attrs["units"] = "s"
+    u = np.linspace(0, 1, 20)
+    da = xr.DataArray(
+        data=array,
+        dims="x",
+        coords={"x": ("x", x, {"units": "s"}), "u": ("x", u, {"units": "hour"})},
+        attrs={"units": "m"},
+    )
     return da
 
 
 @pytest.fixture()
 def example_quantity_da():
     array = np.linspace(0, 10, 20) * unit_registry.m
-    x = np.arange(20) * unit_registry.s
-    return xr.DataArray(data=array, dims="x", coords={"x": x})
+    x = np.arange(20)
+    u = np.linspace(0, 1, 20) * unit_registry.hour
+    return xr.DataArray(
+        data=array, dims="x", coords={"x": ("x", x, {"units": "s"}), "u": ("x", u)},
+    )
 
 
 class TestQuantifyDataArray:

--- a/pint_xarray/tests/test_accessors.py
+++ b/pint_xarray/tests/test_accessors.py
@@ -179,7 +179,7 @@ class TestQuantifyDataSet:
 
     def test_error_when_already_units(self, example_quantity_ds):
         with raises_regex(ValueError, "already has units"):
-            example_quantity_ds.pint.quantify()
+            example_quantity_ds.pint.quantify({"funds": "pounds"})
 
     def test_error_on_nonsense_units(self, example_unitless_ds):
         ds = example_unitless_ds

--- a/pint_xarray/tests/test_conversion.py
+++ b/pint_xarray/tests/test_conversion.py
@@ -193,7 +193,7 @@ class TestXarrayFunctions:
                     data_vars={"a": ("x", []), "b": ("x", [])},
                     coords={"x": [], "u": ("x", [])},
                 ),
-                {"a": "degK", "b": "hPa", "u": "m"},
+                {"a": "K", "b": "hPa", "u": "m"},
                 id="Dataset",
             ),
             pytest.param(Variable("x", []), {None: "hPa"}, id="Variable",),
@@ -354,7 +354,7 @@ class TestXarrayFunctions:
             pytest.param(
                 Dataset(
                     data_vars={
-                        "a": ("x", [], {"units": "degK"}),
+                        "a": ("x", [], {"units": "K"}),
                         "b": ("x", [], {"units": "hPa"}),
                     },
                     coords={
@@ -362,7 +362,7 @@ class TestXarrayFunctions:
                         "u": ("x", [], {"units": "s"}),
                     },
                 ),
-                {"a": "degK", "b": "hPa", "x": "m", "u": "s"},
+                {"a": "K", "b": "hPa", "x": "m", "u": "s"},
                 id="Dataset",
             ),
             pytest.param(
@@ -428,7 +428,7 @@ class TestXarrayFunctions:
             pytest.param(
                 Dataset(
                     data_vars={
-                        "a": ("x", [], {"units": "degK"}),
+                        "a": ("x", [], {"units": "K"}),
                         "b": ("x", [], {"units": "hPa"}),
                     },
                     coords={
@@ -436,7 +436,7 @@ class TestXarrayFunctions:
                         "u": ("x", [], {"units": "s"}),
                     },
                 ),
-                {"a": "degK", "b": "hPa", "x": "m", "u": "s"},
+                {"a": "K", "b": "hPa", "x": "m", "u": "s"},
                 id="Dataset",
             ),
             pytest.param(

--- a/pint_xarray/tests/test_conversion.py
+++ b/pint_xarray/tests/test_conversion.py
@@ -310,6 +310,9 @@ class TestXarrayFunctions:
         assert conversion.extract_units(obj) == units
 
     @pytest.mark.parametrize(
+        "delete", (pytest.param(False, id="keep"), pytest.param(True, id="delete"))
+    )
+    @pytest.mark.parametrize(
         ["obj", "expected"],
         (
             pytest.param(
@@ -340,9 +343,17 @@ class TestXarrayFunctions:
             ),
         ),
     )
-    def test_extract_unit_attributes(self, obj, expected):
-        actual = conversion.extract_unit_attributes(obj, delete=False)
+    def test_extract_unit_attributes(self, obj, expected, delete):
+        actual = conversion.extract_unit_attributes(obj, delete=delete)
         assert expected == actual
+
+        if delete:
+            remaining_attributes = conversion.extract_unit_attributes(obj, delete=False)
+            assert {
+                key: value
+                for key, value in remaining_attributes.items()
+                if value is not None
+            } == {}
 
     @pytest.mark.parametrize(
         "obj",

--- a/pint_xarray/tests/test_conversion.py
+++ b/pint_xarray/tests/test_conversion.py
@@ -379,12 +379,14 @@ class TestXarrayFunctions:
         assert expected == actual
 
         if delete:
-            remaining_attributes = conversion.extract_unit_attributes(obj, delete=False)
-            assert {
+            remaining_attributes = {
                 key: value
-                for key, value in remaining_attributes.items()
+                for key, value in conversion.extract_unit_attributes(
+                    obj, delete=False
+                ).items()
                 if value is not None
-            } == {}
+            }
+            assert remaining_attributes == {}
 
     @pytest.mark.parametrize(
         "obj",

--- a/pint_xarray/tests/test_conversion.py
+++ b/pint_xarray/tests/test_conversion.py
@@ -369,6 +369,9 @@ class TestXarrayFunctions:
                 {"a": "degK", "b": "hPa", "x": "m", "u": "s"},
                 id="Dataset",
             ),
+            pytest.param(
+                Variable("x", [], {"units": "hPa"}), {None: "hPa"}, id="Variable",
+            ),
         ),
     )
     def test_extract_unit_attributes(self, obj, expected, delete):

--- a/pint_xarray/tests/test_conversion.py
+++ b/pint_xarray/tests/test_conversion.py
@@ -177,6 +177,34 @@ class TestXarrayFunctions:
         assert conversion.extract_units(actual) == units
 
     @pytest.mark.parametrize(
+        ["obj", "units"],
+        (
+            pytest.param(
+                DataArray(dims="x", coords={"x": [], "u": ("x", [])}),
+                {None: "hPa", "x": "m"},
+                id="DataArray",
+            ),
+            pytest.param(
+                Dataset(
+                    data_vars={"a": ("x", []), "b": ("x", [])},
+                    coords={"x": [], "u": ("x", [])},
+                ),
+                {"a": "degK", "b": "hPa", "u": "m"},
+                id="Dataset",
+            ),
+            pytest.param(Variable("x", []), {None: "hPa"}, id="Variable",),
+        ),
+    )
+    def test_attach_unit_attributes(self, obj, units):
+        actual = conversion.attach_unit_attributes(obj, units)
+        actual_units = {
+            key: value
+            for key, value in conversion.extract_unit_attributes(actual).items()
+            if value is not None
+        }
+        assert units == actual_units
+
+    @pytest.mark.parametrize(
         "variant",
         (
             "data",

--- a/pint_xarray/tests/test_conversion.py
+++ b/pint_xarray/tests/test_conversion.py
@@ -310,6 +310,41 @@ class TestXarrayFunctions:
         assert conversion.extract_units(obj) == units
 
     @pytest.mark.parametrize(
+        ["obj", "expected"],
+        (
+            pytest.param(
+                DataArray(
+                    coords={
+                        "x": ("x", [], {"units": "m"}),
+                        "u": ("x", [], {"units": "s"}),
+                    },
+                    attrs={"units": "hPa"},
+                    dims="x",
+                ),
+                {"x": "m", "u": "s", None: "hPa"},
+                id="DataArray",
+            ),
+            pytest.param(
+                Dataset(
+                    data_vars={
+                        "a": ("x", [], {"units": "degK"}),
+                        "b": ("x", [], {"units": "hPa"}),
+                    },
+                    coords={
+                        "x": ("x", [], {"units": "m"}),
+                        "u": ("x", [], {"units": "s"}),
+                    },
+                ),
+                {"a": "degK", "b": "hPa", "x": "m", "u": "s"},
+                id="Dataset",
+            ),
+        ),
+    )
+    def test_extract_unit_attributes(self, obj, expected):
+        actual = conversion.extract_unit_attributes(obj, delete=False)
+        assert expected == actual
+
+    @pytest.mark.parametrize(
         "obj",
         (
             pytest.param(Variable("x", [0, 4, 3] * unit_registry.m), id="Variable"),

--- a/pint_xarray/tests/utils.py
+++ b/pint_xarray/tests/utils.py
@@ -5,7 +5,7 @@ import numpy as np
 import pytest
 import xarray as xr
 from pint.quantity import Quantity
-from xarray.testing import assert_equal  # noqa: F401
+from xarray.testing import assert_equal, assert_identical  # noqa: F401
 
 
 @contextmanager

--- a/pint_xarray/tests/utils.py
+++ b/pint_xarray/tests/utils.py
@@ -5,7 +5,7 @@ import numpy as np
 import pytest
 import xarray as xr
 from pint.quantity import Quantity
-from xarray.testing import assert_equal, assert_identical  # noqa: F401
+from xarray.testing import assert_equal  # noqa: F401
 
 
 @contextmanager


### PR DESCRIPTION
Since we now have the utils from #11, `quantify` and `dequantify` can be extended to also support coordinates.

I'm also hoping to fix #9, either by changing the check in `Variable.data` (I need to think more about the implications of that) or by stating that this will load non-dask arrays into memory.