### PR TITLE
update the github url of sphinx-autosummary-accessors

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,4 +3,4 @@ xarray>=0.15.1
 sphinx>=3.0
 sphinx_rtd_theme
 nbsphinx
-git+https://github.com/keewis/sphinx-autosummary-accessors
+git+https://github.com/xarray-contrib/sphinx-autosummary-accessors


### PR DESCRIPTION
`sphinx-autosummary-accessors` – used to document pandas or xarray accessors – has been moved to `xarray-contrib`.