### PR TITLE
install from pypi

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,4 +3,4 @@ xarray>=0.15.1
 sphinx>=3.0
 sphinx_rtd_theme
 nbsphinx
-git+https://github.com/xarray-contrib/sphinx-autosummary-accessors
+sphinx-autosummary-accessors


### PR DESCRIPTION
I recently released `sphinx-autosummary-accessors`, this updates the requirements file to install from PyPI instead of github.