### PR TITLE
populate whats-new.rst with merged feature PRs

### DIFF
--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -3,4 +3,10 @@ What's new
 
 0.1 (*unreleased*)
 ------------------
-- add documentation (:pull:`20`)
+- add initial draft of documentation (:pull:`13`, :pull:`20`)
+- implement :py:meth:`DataArray.pint.to` and :py:meth:`Dataset.pint.to`
+  (:pull:`11`)
+- rewrite :py:meth:`DataArray.pint.quantify`,
+  :py:meth:`Dataset.pint.quantify`, :py:meth:`DataArray.pint.dequantify` and
+  :py:meth:`Dataset.pint.dequantify` (:pull:`17`)
+- expose :py:func:`pint_xarray.testing.assert_units_equal` as public API (:pull:`24`)


### PR DESCRIPTION
Not sure what our policy for the changelog should be. I'd include everything except internal PRs.