### PR TITLE
Update ci and git hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,19 +2,19 @@
 repos:
   # isort should run before black as black sometimes tweaks the isort output
   - repo: https://github.com/timothycrosley/isort
-    rev: 4.3.21
+    rev: 5.4.2
     hooks:
       - id: isort
   # https://github.com/python/black#version-control-integration
   - repo: https://github.com/python/black
-    rev: stable
+    rev: 20.8b1
     hooks:
       - id: black
   - repo: https://github.com/keewis/blackdoc
-    rev: stable
+    rev: v0.1.2
     hooks:
       - id: blackdoc
   - repo: https://gitlab.com/pycqa/flake8
-    rev: 3.8.1
+    rev: 3.8.3
     hooks:
       - id: flake8

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -70,19 +70,19 @@ jobs:
   - bash: python -m black --check .
     displayName: black formatting check
 
-# - job: FormattingBlackdoc
-#   variables:
-#     python.version: '3.8'
-#   pool:
-#     vmImage: 'ubuntu-20.04'
-#   steps:
-#   - task: UsePythonVersion@0
-#     inputs:
-#       versionSpec: '$(python.version)'
-#     displayName: 'Use Python $(python.version)'
-#   - bash: python -m pip install blackdoc
-#     displayName: Install blackdoc
-#   - bash: python -m pip list
-#     displayName: Version Info
-#   - bash: python -m blackdoc --check .
-#     displayName: blackdoc formatting check
+- job: FormattingBlackdoc
+  variables:
+    python.version: '3.8'
+  pool:
+    vmImage: 'ubuntu-20.04'
+  steps:
+  - task: UsePythonVersion@0
+    inputs:
+      versionSpec: '$(python.version)'
+    displayName: 'Use Python $(python.version)'
+  - bash: python -m pip install blackdoc
+    displayName: Install blackdoc
+  - bash: python -m pip list
+    displayName: Version Info
+  - bash: python -m blackdoc --check .
+    displayName: blackdoc formatting check


### PR DESCRIPTION
Updates the pre-commit hook version and re-enables the `blackdoc` CI, now that it is once again compatible with the latest version of `black`.