### PR TITLE
Fix the units and dimensionality properties

### DIFF
--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -10,3 +10,6 @@ What's new
   :py:meth:`Dataset.pint.quantify`, :py:meth:`DataArray.pint.dequantify` and
   :py:meth:`Dataset.pint.dequantify` (:pull:`17`)
 - expose :py:func:`pint_xarray.testing.assert_units_equal` as public API (:pull:`24`)
+- fix the :py:attr:`DataArray.pint.units`, :py:attr:`DataArray.pint.magnitude`
+  and :py:attr:`DataArray.pint.dimensionality` properties and add docstrings for
+  all three. (:pull:`31`)

--- a/pint_xarray/accessors.py
+++ b/pint_xarray/accessors.py
@@ -236,7 +236,10 @@ class PintDataArrayAccessor:
 
     @property
     def units(self):
-        """the units of the data or :py:obj:`None` if not a quantity."""
+        """the units of the data or :py:obj:`None` if not a quantity.
+
+        The units can only be set if the data is not already a quantity.
+        """
         return getattr(self.da.data, "units", None)
 
     @units.setter

--- a/pint_xarray/accessors.py
+++ b/pint_xarray/accessors.py
@@ -4,7 +4,7 @@ import itertools
 import pint
 from pint.quantity import Quantity
 from pint.unit import Unit
-from xarray import DataArray, register_dataarray_accessor, register_dataset_accessor
+from xarray import register_dataarray_accessor, register_dataset_accessor
 from xarray.core.npcompat import IS_NEP18_ACTIVE
 
 from . import conversion
@@ -249,9 +249,7 @@ class PintDataArrayAccessor:
     @units.setter
     def units(self, units):
         quantity = conversion.array_attach_units(self.da.data, units)
-        self.da = DataArray(
-            dim=self.da.dims, data=quantity, coords=self.da.coords, attrs=self.da.attrs
-        )
+        self.da.data = quantity
 
     @property
     def dimensionality(self):

--- a/pint_xarray/accessors.py
+++ b/pint_xarray/accessors.py
@@ -230,48 +230,23 @@ class PintDataArrayAccessor:
 
     @property
     def magnitude(self):
-        """get the magnitude of the wrapped data
-
-        If not a quantity, will return the data itself.
-        """
+        """the magnitude of the data or the data itself if not a quantity."""
         data = self.da.data
         return getattr(data, "magnitude", data)
 
     @property
     def units(self):
-        """get the units of the wrapped data
-
-        Returns
-        -------
-        units : pint.Unit or None
-            the units of the wrapped data. If it is not a quantity, the units
-            are :py:obj:`None`.
-        """
+        """the units of the data or :py:obj:`None` if not a quantity."""
         return getattr(self.da.data, "units", None)
 
     @units.setter
     def units(self, units):
-        """set the units of the wrapped data in-place
-
-        Raises
-        ------
-        ValueError
-            If the data already is a quantity, or the units are not a
-            :py:class:`pint.Unit` instance.
-        """
         quantity = conversion.array_attach_units(self.da.data, units)
         self.da.data = quantity
 
     @property
     def dimensionality(self):
-        """get the dimensionality of the data
-
-        Returns
-        -------
-        dimensionality : str or None
-            The dimensionality of the data. If it is not a quantity, the
-            dimensionality is :py:obj:`None`.
-        """
+        """get the dimensionality of the data or :py:obj:`None` if not a quantity."""
         return getattr(self.da.data, "dimensionality", None)
 
     @property

--- a/pint_xarray/accessors.py
+++ b/pint_xarray/accessors.py
@@ -240,7 +240,12 @@ class PintDataArrayAccessor:
 
     @property
     def magnitude(self):
-        return self.da.data.magnitude
+        """get the magnitude of the wrapped data
+
+        If not a quantity, will return the data itself.
+        """
+        data = self.da.data
+        return getattr(data, "magnitude", data)
 
     @property
     def units(self):

--- a/pint_xarray/accessors.py
+++ b/pint_xarray/accessors.py
@@ -244,7 +244,7 @@ class PintDataArrayAccessor:
 
     @property
     def units(self):
-        return self.da.data.units
+        return getattr(self.da.data, "units", None)
 
     @units.setter
     def units(self, units):

--- a/pint_xarray/accessors.py
+++ b/pint_xarray/accessors.py
@@ -244,8 +244,7 @@ class PintDataArrayAccessor:
 
     @units.setter
     def units(self, units):
-        quantity = conversion.array_attach_units(self.da.data, units)
-        self.da.data = quantity
+        self.da.data = conversion.array_attach_units(self.da.data, units)
 
     @property
     def dimensionality(self):

--- a/pint_xarray/accessors.py
+++ b/pint_xarray/accessors.py
@@ -277,7 +277,7 @@ class PintDataArrayAccessor:
             The dimensionality of the data. If it is not a quantity, the
             dimensionality is :py:obj:`None`.
         """
-        return self.da.data.dimensionality
+        return getattr(self.da.data, "dimensionality", None)
 
     @property
     def registry(self):

--- a/pint_xarray/accessors.py
+++ b/pint_xarray/accessors.py
@@ -238,7 +238,7 @@ class PintDataArrayAccessor:
     def units(self):
         """the units of the data or :py:obj:`None` if not a quantity.
 
-        The units can only be set if the data is not already a quantity.
+        Setting the units is possible, but only if the data is not already a quantity.
         """
         return getattr(self.da.data, "units", None)
 

--- a/pint_xarray/accessors.py
+++ b/pint_xarray/accessors.py
@@ -244,15 +244,39 @@ class PintDataArrayAccessor:
 
     @property
     def units(self):
+        """get the units of the wrapped data
+
+        Returns
+        -------
+        units : pint.Unit or None
+            the units of the wrapped data. If it is not a quantity, the units
+            are :py:obj:`None`.
+        """
         return getattr(self.da.data, "units", None)
 
     @units.setter
     def units(self, units):
+        """set the units of the wrapped data in-place
+
+        Raises
+        ------
+        ValueError
+            If the data already is a quantity, or the units are not a
+            :py:class:`pint.Unit` instance.
+        """
         quantity = conversion.array_attach_units(self.da.data, units)
         self.da.data = quantity
 
     @property
     def dimensionality(self):
+        """get the dimensionality of the data
+
+        Returns
+        -------
+        dimensionality : str or None
+            The dimensionality of the data. If it is not a quantity, the
+            dimensionality is :py:obj:`None`.
+        """
         return self.da.data.dimensionality
 
     @property

--- a/pint_xarray/tests/test_accessors.py
+++ b/pint_xarray/tests/test_accessors.py
@@ -144,11 +144,11 @@ class TestPropertiesDataArray:
         with pytest.raises(ValueError):
             da.pint.units = "s"
 
-    def test_unit_getattr_unitless(self, example_unitless_da):
+    def test_units_getattr_unitless(self, example_unitless_da):
         da = example_unitless_da
         assert da.pint.units is None
 
-    def test_unit_setattr_unitless(self, example_unitless_da):
+    def test_units_setattr_unitless(self, example_unitless_da):
         da = example_unitless_da
         da.pint.units = unit_registry.s
         assert da.pint.units == unit_registry.s

--- a/pint_xarray/tests/test_accessors.py
+++ b/pint_xarray/tests/test_accessors.py
@@ -124,10 +124,20 @@ class TestDequantifyDataArray:
 
 
 class TestPropertiesDataArray:
+    def test_magnitude_getattr(self, example_quantity_da):
+        da = example_quantity_da
+        actual = da.pint.magnitude
+        assert not isinstance(actual, Quantity)
+
+    def test_magnitude_getattr_unitless(self, example_unitless_da):
+        da = example_unitless_da
+        xr.testing.assert_duckarray_equal(da.pint.magnitude, da.data)
+
     def test_units_getattr(self, example_quantity_da):
         da = example_quantity_da
-        assert isinstance(da.pint.units, Unit)
-        assert da.pint.units == unit_registry.m
+        actual = da.pint.units
+        assert isinstance(actual, Unit)
+        assert actual == unit_registry.m
 
     def test_units_setattr(self, example_quantity_da):
         da = example_quantity_da

--- a/pint_xarray/tests/test_accessors.py
+++ b/pint_xarray/tests/test_accessors.py
@@ -123,6 +123,17 @@ class TestDequantifyDataArray:
         assert_equal(result, orig)
 
 
+class TestPropertiesDataArray:
+    def test_units_getattr(self, example_quantity_da):
+        da = example_quantity_da
+        assert isinstance(da.pint.units, Unit)
+        assert da.pint.units == unit_registry.m
+
+    def test_unit_getattr_unitless(self, example_unitless_da):
+        da = example_unitless_da
+        assert da.pint.units is None
+
+
 @pytest.fixture()
 def example_unitless_ds():
     users = np.linspace(0, 10, 20)

--- a/pint_xarray/tests/test_accessors.py
+++ b/pint_xarray/tests/test_accessors.py
@@ -129,9 +129,19 @@ class TestPropertiesDataArray:
         assert isinstance(da.pint.units, Unit)
         assert da.pint.units == unit_registry.m
 
+    def test_units_setattr(self, example_quantity_da):
+        da = example_quantity_da
+        with pytest.raises(ValueError):
+            da.pint.units = "s"
+
     def test_unit_getattr_unitless(self, example_unitless_da):
         da = example_unitless_da
         assert da.pint.units is None
+
+    def test_unit_setattr_unitless(self, example_unitless_da):
+        da = example_unitless_da
+        da.pint.units = unit_registry.s
+        assert da.pint.units == unit_registry.s
 
 
 @pytest.fixture()


### PR DESCRIPTION
`DataArray.pint.units.__set__` was broken, it would silently discard the requested units. Also, `DataArray.pint.units.__get__` and `DataArray.pint.dimensionality.__get__` would fail for non-quantities.

This fixes those issues, and also adds docstrings to both properties.