### PR TITLE
add a module-global registry

### DIFF
--- a/docs/creation.rst
+++ b/docs/creation.rst
@@ -40,7 +40,7 @@ We can also override the units of a variable:
 
     In [4]: ds.pint.quantify(b="km")
 
-    In [5]: da.pint.quantify({"b": "degree"})
+    In [5]: da.pint.quantify("degree")
 
 Overriding works, even if there is no ``units`` attribute, so we could use this
 to attach units to a normal :py:class:`Dataset`:

--- a/docs/creation.rst
+++ b/docs/creation.rst
@@ -8,8 +8,9 @@ Attaching units
 .. ipython:: python
     :suppress:
 
-    import xarray as xr
     import pint
+    import pint_xarray
+    import xarray as xr
 
 Usually, when loading data from disk we get a :py:class:`Dataset` or
 :py:class:`DataArray` with units in attributes:

--- a/docs/creation.rst
+++ b/docs/creation.rst
@@ -83,6 +83,31 @@ have to first swap the dimensions:
        ...: )
        ...: da_with_units
 
+By default, :py:meth:`Dataset.pint.quantify` and
+:py:meth:`DataArray.pint.quantify` will use the unit registry at
+:py:obj:`pint_xarray.unit_registry`. If we want a different registry, we can
+either pass it as the ``unit_registry`` parameter:
+
+.. ipython::
+
+   In [10]: ureg = pint.UnitRegistry(force_ndarray_like=True)
+       ...: # set up the registry
+
+   In [11]: da.pint.quantify("degree", unit_registry=ureg)
+
+or overwrite the default registry:
+
+.. ipython::
+
+   In [12]: pint_xarray.unit_registry = ureg
+
+   In [13]: da.pint.quantify("degree")
+
+.. note::
+
+    To properly work with ``xarray``, the ``force_ndarray_like`` or
+    ``force_ndarray`` options have to be enabled on the custom registry.
+
 Saving with units
 -----------------
 In order to not lose the units when saving to disk, we first have to call the

--- a/docs/creation.rst
+++ b/docs/creation.rst
@@ -53,6 +53,13 @@ to attach units to a normal :py:class:`Dataset`:
 Of course, we could use :py:class:`pint.Unit` instances instead of strings to
 specify units, too.
 
+.. note::
+
+    Unit objects tied to different registries cannot interact with each
+    other. In order to avoid this, :py:meth:`DataArray.pint.quantify` and
+    :py:meth:`Dataset.pint.quantify` will make sure only a single registry is
+    used per ``xarray`` object.
+
 If we wanted to change the units of the data of a :py:class:`DataArray`, we
 could do so using the :py:attr:`DataArray.name` attribute:
 

--- a/docs/creation.rst
+++ b/docs/creation.rst
@@ -42,7 +42,7 @@ We can also override the units of a variable:
 
     In [5]: da.pint.quantify("degree")
 
-Overriding works, even if there is no ``units`` attribute, so we could use this
+Overriding works even if there is no ``units`` attribute, so we could use this
 to attach units to a normal :py:class:`Dataset`:
 
 .. ipython::

--- a/docs/creation.rst
+++ b/docs/creation.rst
@@ -87,8 +87,9 @@ have to first swap the dimensions:
 
 By default, :py:meth:`Dataset.pint.quantify` and
 :py:meth:`DataArray.pint.quantify` will use the unit registry at
-:py:obj:`pint_xarray.unit_registry`. If we want a different registry, we can
-either pass it as the ``unit_registry`` parameter:
+:py:obj:`pint_xarray.unit_registry` (the
+:py:func:`application registry <pint.get_application_registry>`). If we want a
+different registry, we can either pass it as the ``unit_registry`` parameter:
 
 .. ipython::
 

--- a/docs/creation.rst
+++ b/docs/creation.rst
@@ -9,6 +9,7 @@ Attaching units
     :suppress:
 
     import xarray as xr
+    import pint
 
 Usually, when loading data from disk we get a :py:class:`Dataset` or
 :py:class:`DataArray` with units in attributes:

--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -13,3 +13,4 @@ What's new
 - fix the :py:attr:`DataArray.pint.units`, :py:attr:`DataArray.pint.magnitude`
   and :py:attr:`DataArray.pint.dimensionality` properties and add docstrings for
   all three. (:pull:`31`)
+- use ``pint``'s application registry as a module-global registry (:pull:`32`)

--- a/pint_xarray/__init__.py
+++ b/pint_xarray/__init__.py
@@ -8,6 +8,7 @@ import pint
 from . import testing  # noqa: F401
 from . import formatting
 from .accessors import PintDataArrayAccessor, PintDatasetAccessor  # noqa: F401
+from .accessors import _registry as unit_registry  # noqa: F401
 
 try:
     __version__ = version("pint-xarray")

--- a/pint_xarray/__init__.py
+++ b/pint_xarray/__init__.py
@@ -8,7 +8,7 @@ import pint
 from . import testing  # noqa: F401
 from . import formatting
 from .accessors import PintDataArrayAccessor, PintDatasetAccessor  # noqa: F401
-from .accessors import _registry as unit_registry  # noqa: F401
+from .accessors import default_registry as unit_registry  # noqa: F401
 
 try:
     __version__ = version("pint-xarray")

--- a/pint_xarray/accessors.py
+++ b/pint_xarray/accessors.py
@@ -8,7 +8,7 @@ from xarray import DataArray, register_dataarray_accessor, register_dataset_acce
 
 from . import conversion
 
-_registry = pint.UnitRegistry(force_ndarray_like=True)
+default_registry = pint.UnitRegistry(force_ndarray_like=True)
 
 # TODO could/should we overwrite xr.open_dataset and xr.open_mfdataset to make
 # them apply units upon loading???
@@ -90,7 +90,7 @@ def get_registry(unit_registry, new_units, existing_units):
 
     if unit_registry is None:
         if not registries:
-            unit_registry = _registry
+            unit_registry = default_registry
         elif len(registries) == 1:
             (unit_registry,) = registries
     registries.add(unit_registry)

--- a/pint_xarray/accessors.py
+++ b/pint_xarray/accessors.py
@@ -8,7 +8,7 @@ from xarray import register_dataarray_accessor, register_dataset_accessor
 
 from . import conversion
 
-default_registry = pint.UnitRegistry(force_ndarray_like=True)
+default_registry = pint.get_application_registry()
 
 
 def setup_registry(registry=None):

--- a/pint_xarray/accessors.py
+++ b/pint_xarray/accessors.py
@@ -10,6 +10,32 @@ from . import conversion
 
 default_registry = pint.UnitRegistry(force_ndarray_like=True)
 
+
+def setup_registry(registry=None):
+    """set up the given registry for use with pint_xarray
+
+    Namely, it enables ``force_ndarray_like`` to make sure results are always
+    duck arrays.
+
+    Parameters
+    ----------
+    registry : pint.UnitRegistry, optional
+        The registry to use. If not given, the application registry is used.
+
+    See also
+    --------
+    pint.get_application_registry
+    pint.set_application_registry
+    """
+    if registry is None:
+        registry = default_registry
+
+    if not registry.force_ndarray and not registry.force_ndarray_like:
+        registry.force_ndarray_like = True
+
+    return registry
+
+
 # TODO could/should we overwrite xr.open_dataset and xr.open_mfdataset to make
 # them apply units upon loading???
 # TODO could even override the decode_cf kwarg?

--- a/pint_xarray/accessors.py
+++ b/pint_xarray/accessors.py
@@ -95,7 +95,8 @@ def either_dict_or_kwargs(positional, keywords, method_name):
         return keywords
 
 
-def get_registry(unit_registry, units):
+def get_registry(unit_registry, new_units, existing_units):
+    units = merge_mappings(existing_units, new_units)
     registries = {unit._REGISTRY for unit in units.values() if isinstance(unit, Unit)}
 
     if unit_registry is None:
@@ -221,7 +222,8 @@ class PintDataArrayAccessor:
 
         registry = get_registry(
             unit_registry,
-            merge_mappings(units, conversion.extract_units(self.da)),
+            units,
+            conversion.extract_units(self.da),
         )
 
         unit_attrs = conversion.extract_unit_attributes(self.da)
@@ -487,7 +489,8 @@ class PintDatasetAccessor:
         units = either_dict_or_kwargs(units, unit_kwargs, ".quantify")
         registry = get_registry(
             unit_registry,
-            merge_mappings(units, conversion.extract_units(self.ds)),
+            units,
+            conversion.extract_units(self.ds),
         )
 
         unit_attrs = conversion.extract_unit_attributes(self.ds)

--- a/pint_xarray/accessors.py
+++ b/pint_xarray/accessors.py
@@ -63,7 +63,9 @@ def zip_mappings(*mappings, fill_value=None):
 def merge_mappings(first, *mappings):
     result = first.copy()
     for mapping in mappings:
-        result.update(mapping)
+        result.update(
+            {key: value for key, value in mapping.items() if value is not None}
+        )
 
     return result
 
@@ -99,9 +101,9 @@ def get_registry(unit_registry, units):
     if unit_registry is None:
         if not registries:
             unit_registry = _registry
-            registries.add(unit_registry)
         elif len(registries) == 1:
             (unit_registry,) = registries
+    registries.add(unit_registry)
 
     if len(registries) > 1 or unit_registry not in registries:
         raise ValueError(

--- a/pint_xarray/accessors.py
+++ b/pint_xarray/accessors.py
@@ -285,7 +285,7 @@ class PintDataArrayAccessor:
     @property
     def registry(self):
         # TODO is this a bad idea? (see GH issue #1071 in pint)
-        return self.data._REGISTRY
+        return getattr(self.da.data, "_REGISTRY", None)
 
     @registry.setter
     def registry(self, _):

--- a/pint_xarray/accessors.py
+++ b/pint_xarray/accessors.py
@@ -8,10 +8,8 @@ from xarray import register_dataarray_accessor, register_dataset_accessor
 
 from . import conversion
 
-default_registry = pint.get_application_registry()
 
-
-def setup_registry(registry=None):
+def setup_registry(registry):
     """set up the given registry for use with pint_xarray
 
     Namely, it enables ``force_ndarray_like`` to make sure results are always
@@ -27,14 +25,13 @@ def setup_registry(registry=None):
     pint.get_application_registry
     pint.set_application_registry
     """
-    if registry is None:
-        registry = default_registry
-
     if not registry.force_ndarray and not registry.force_ndarray_like:
         registry.force_ndarray_like = True
 
     return registry
 
+
+default_registry = setup_registry(pint.get_application_registry())
 
 # TODO could/should we overwrite xr.open_dataset and xr.open_mfdataset to make
 # them apply units upon loading???

--- a/pint_xarray/accessors.py
+++ b/pint_xarray/accessors.py
@@ -17,13 +17,8 @@ def setup_registry(registry):
 
     Parameters
     ----------
-    registry : pint.UnitRegistry, optional
-        The registry to use. If not given, the application registry is used.
-
-    See also
-    --------
-    pint.get_application_registry
-    pint.set_application_registry
+    registry : pint.UnitRegistry
+        The registry to modify
     """
     if not registry.force_ndarray and not registry.force_ndarray_like:
         registry.force_ndarray_like = True

--- a/pint_xarray/accessors.py
+++ b/pint_xarray/accessors.py
@@ -18,6 +18,9 @@ if not IS_NEP18_ACTIVE:
     raise ImportError("NUMPY_EXPERIMENTAL_ARRAY_FUNCTION is not enabled")
 
 
+_registry = pint.UnitRegistry(force_ndarray_like=True)
+
+
 # TODO could/should we overwrite xr.open_dataset and xr.open_mfdataset to make
 # them apply units upon loading???
 # TODO could even override the decode_cf kwarg?
@@ -95,7 +98,7 @@ def get_registry(unit_registry, units):
 
     if unit_registry is None:
         if not registries:
-            unit_registry = pint.get_application_registry()
+            unit_registry = _registry
             registries.add(unit_registry)
         elif len(registries) == 1:
             (unit_registry,) = registries

--- a/pint_xarray/tests/test_accessors.py
+++ b/pint_xarray/tests/test_accessors.py
@@ -94,11 +94,6 @@ class TestQuantifyDataArray:
         with pytest.raises(UndefinedUnitError):
             da.pint.quantify(units="aecjhbav")
 
-    def test_registry_kwargs(self, example_unitless_da):
-        orig = example_unitless_da
-        result = orig.pint.quantify(registry_kwargs={"auto_reduce_dimensions": True})
-        assert result.data._REGISTRY.auto_reduce_dimensions is True
-
 
 class TestDequantifyDataArray:
     def test_strip_units(self, example_quantity_da):


### PR DESCRIPTION
This is an attempt to fix the registry creation as discussed in #7. It will make sure that the selected registry is usable (i.e `force_ndarray_like` or `force_ndarray` are set) and that only a single registry is used. To make `ds.pint.quantify()` work without any boilerplate code, it also introduces a module-global unit registry (`pint_xarray.unit_registry`). For now, if someone wants a different unit registry, they need to call `.quantify` with that registry – subsequent calls to `.quantify` on the same object will then use that registry and reject other registries – or maybe set
```python
pint_xarray.unit_registry = pint.UnitRegistry(..., force_ndarray_like=True)
```

I'm not quite sure if this is a good API so this is a draft for now.

- [x] closes #7