### PR TITLE
remove the explicit checks for Quantity.__array_function__ and NEP18

### DIFF
--- a/pint_xarray/accessors.py
+++ b/pint_xarray/accessors.py
@@ -5,18 +5,8 @@ import pint
 from pint.quantity import Quantity
 from pint.unit import Unit
 from xarray import DataArray, register_dataarray_accessor, register_dataset_accessor
-from xarray.core.npcompat import IS_NEP18_ACTIVE
 
 from . import conversion
-
-if not hasattr(Quantity, "__array_function__"):
-    raise ImportError(
-        "Imported version of pint does not implement " "__array_function__"
-    )
-
-if not IS_NEP18_ACTIVE:
-    raise ImportError("NUMPY_EXPERIMENTAL_ARRAY_FUNCTION is not enabled")
-
 
 # TODO could/should we overwrite xr.open_dataset and xr.open_mfdataset to make
 # them apply units upon loading???

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,8 +9,8 @@ url = https://github.com/TomNicholas/pint-xarray
 packages = find:
 python_requires = >=3.6
 install_requires =
-    numpy >= 1.17.1
-    xarray >= 0.15.1
+    numpy >= 1.17
+    xarray >= 0.16
     pint >= 0.13
     importlib-metadata; python_version < "3.8"
 


### PR DESCRIPTION
These are not necessary because we require `pint>=0.13` and `numpy>=1.17` in `setup.cfg`.