### PR TITLE
Prepare release

### DIFF
--- a/HOW_TO_RELEASE.rst
+++ b/HOW_TO_RELEASE.rst
@@ -21,48 +21,17 @@ Release process
 
       git commit --allow-empty -am "Release v0.X.Y"
 
-7. Tag the release:
+7. Tag the release and push to master:
 
    .. code:: sh
 
       git tag -a v0.X.Y -m "v0.X.Y"
-
-8. Build source and binary wheels:
-
-   .. code:: sh
-
-      git clean -xdf
-      python -m pep517.build --source --binary .
-
-9. Use `twine` to check the package build:
-
-   .. code:: sh
-
-      twine check dist/*
-
-10. try installing the wheel in a new environment and run the tests 
-
-   .. code:: bash
-
-      python -m venv test
-      source test/bin/activate
-      python -m pip install -r requirements.txt
-      python -m pip install pytest
-      python -m pip install dist/*.whl
-      python -m pytest
-      git reset --hard HEAD
-
-11. Push to master and upload to PyPI:
-
-   .. code:: sh
-
-      git push origin master
       git push origin --tags
-      twine upload dist/*
 
-   Be careful, this can't be undone.
+8. Draft a release for the new tag on github. A CI will pick that up, build the project
+   and push to PyPI. Be careful, this can't be undone.
               
-12. Update stable:
+9. Update stable:
 
     .. code:: sh
 
@@ -70,6 +39,6 @@ Release process
        git merge v0.X.Y
        git push origin stable
 
-13. Make sure readthedocs builds both `stable` and the new tag
+10. Make sure readthedocs builds both `stable` and the new tag
 
-14. Add a new section to `whats-new.rst` and push directly to master
+11. Add a new section to `whats-new.rst` and push directly to master

--- a/HOW_TO_RELEASE.rst
+++ b/HOW_TO_RELEASE.rst
@@ -1,0 +1,75 @@
+Release process
+===============
+1. the release happens from `master` so make sure it is up-to-date:
+
+   .. code:: sh
+
+      git pull origin master
+
+2. look at `whats-new.rst` and make sure it is complete and with
+   references to issues and pull requests
+
+3. open and merge a pull request with these changes and update the release date
+
+4. run the test suite
+
+5. check that the documentation is building
+
+6. Commit the release:
+
+   .. code:: sh
+
+      git commit --allow-empty -am "Release v0.X.Y"
+
+7. Tag the release:
+
+   .. code:: sh
+
+      git tag -a v0.X.Y -m "v0.X.Y"
+
+8. Build source and binary wheels:
+
+   .. code:: sh
+
+      git clean -xdf
+      python -m pep517.build --source --binary .
+
+9. Use `twine` to check the package build:
+
+   .. code:: sh
+
+      twine check dist/*
+
+10. try installing the wheel in a new environment and run the tests 
+
+   .. code:: bash
+
+      python -m venv test
+      source test/bin/activate
+      python -m pip install -r requirements.txt
+      python -m pip install pytest
+      python -m pip install dist/*.whl
+      python -m pytest
+      git reset --hard HEAD
+
+11. Push to master and upload to PyPI:
+
+   .. code:: sh
+
+      git push origin master
+      git push origin --tags
+      twine upload dist/*
+
+   Be careful, this can't be undone.
+              
+12. Update stable:
+
+    .. code:: sh
+
+       git checkout stable
+       git merge v0.X.Y
+       git push origin stable
+
+13. Make sure readthedocs builds both `stable` and the new tag
+
+14. Add a new section to `whats-new.rst` and push directly to master

--- a/HOW_TO_RELEASE.rst
+++ b/HOW_TO_RELEASE.rst
@@ -9,7 +9,7 @@ Release process
 2. look at `whats-new.rst` and make sure it is complete and with
    references to issues and pull requests
 
-3. open and merge a pull request with these changes and update the release date
+3. open and merge a pull request with these changes and the filled in release date
 
 4. run the test suite
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -5,6 +5,11 @@ A convenience wrapper for using `pint`_ in `xarray`_ objects.
 .. _pint: https://pint.readthedocs.io/en/stable
 .. _xarray: https://xarray.pydata.org/en/stable
 
+.. warning::
+
+   This package is experimental, and new versions might introduce backwards incompatible
+   changes.
+
 Documentation
 -------------
 

--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -1,8 +1,8 @@
 What's new
 ==========
 
-0.1 (*unreleased*)
-------------------
+0.1 (October 26 2020)
+---------------------
 - add initial draft of documentation (:pull:`13`, :pull:`20`)
 - implement :py:meth:`DataArray.pint.to` and :py:meth:`Dataset.pint.to`
   (:pull:`11`)


### PR DESCRIPTION
As stated in #25, a alpha release would be useful to increase the testing of the library, and to get feedback on the API design.

In addition to preparing for the first release, this PR adds a release guide (it is based on `blackdoc`'s release guide, which in turn is heavily inspired by `xarray`'s guide).