### PR TITLE
add a CI publishing to PyPI

### DIFF
--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -1,0 +1,30 @@
+name: Upload Package to PyPI
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - name: Set up Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip pep517 twine
+      - name: Build
+        run: |
+          python -m pep517.build --source --binary --out-dir dist/ .
+      - name: Check the built archives
+        run: |
+          twine check dist/*
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@1.4
+        with:
+          user: __token__
+          password: ${{ secrets.pypi_password }}
+          repository_url: https://test.pypi.org/legacy/

--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -23,7 +23,7 @@ jobs:
         run: |
           twine check dist/*
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@1.4
+        uses: pypa/gh-action-pypi-publish@v1.4.1
         with:
           user: __token__
           password: ${{ secrets.pypi_password }}

--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -27,4 +27,4 @@ jobs:
         with:
           user: __token__
           password: ${{ secrets.pypi_password }}
-          repository_url: https://test.pypi.org/legacy/
+          repository_url: https://upload.pypi.org/legacy/


### PR DESCRIPTION
As per https://github.com/xarray-contrib/pint-xarray/pull/35#issuecomment-716710014 (thanks for the tip, @dcherian), this adds a CI automatically publishing to PyPI after a release was created.