### PR TITLE
use the commit hash to pin the publish-to-pypi action

### DIFF
--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -23,7 +23,7 @@ jobs:
         run: |
           twine check dist/*
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@v1.4.1
+        uses: pypa/gh-action-pypi-publish@54b39fb9371c0b3a6f9f14bb8a67394defc7a806
         with:
           user: __token__
           password: ${{ secrets.pypi_password }}


### PR DESCRIPTION
This guards against a change in behavior by republishing a tag (which is dangerous because it could leak the PyPI token).