### PR TITLE
refactor the conversion functions

### DIFF
--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -5,6 +5,7 @@ What's new
 ------------------
 - rewrite :py:meth:`Dataset.pint.quantify` and :py:meth:`DataArray.pint.quantify`,
   to use pint's `parse_units` instead of `parse_expression` (:pull:`40`)
+- refactor the internal conversion functions (:pull:``)
 
 v0.1 (October 26 2020)
 ----------------------

--- a/pint_xarray/accessors.py
+++ b/pint_xarray/accessors.py
@@ -225,7 +225,7 @@ class PintDataArrayAccessor:
             unit_kwargs[self.da.name] = units
             units = None
 
-        units = either_dict_or_kwargs(units, unit_kwargs, ".quantify")
+        units = either_dict_or_kwargs(units, unit_kwargs, "quantify")
 
         registry = get_registry(unit_registry, units, conversion.extract_units(self.da))
 
@@ -489,7 +489,7 @@ class PintDatasetAccessor:
             a        (x) int64 <Quantity([0 3 2], 'meter')>
             b        (x) int64 <Quantity([ 5 -2  1], 'decimeter')>
         """
-        units = either_dict_or_kwargs(units, unit_kwargs, ".quantify")
+        units = either_dict_or_kwargs(units, unit_kwargs, "quantify")
         registry = get_registry(unit_registry, units, conversion.extract_units(self.ds))
 
         unit_attrs = conversion.extract_unit_attributes(self.ds)

--- a/pint_xarray/accessors.py
+++ b/pint_xarray/accessors.py
@@ -230,7 +230,6 @@ class PintDataArrayAccessor:
         registry = get_registry(unit_registry, units, conversion.extract_units(self.da))
 
         unit_attrs = conversion.extract_unit_attributes(self.da)
-        new_obj = conversion.strip_unit_attributes(self.da)
 
         units = {
             name: _decide_units(unit, registry, unit_attribute)
@@ -242,9 +241,12 @@ class PintDataArrayAccessor:
         dim_units = {name: unit for name, unit in units.items() if name in self.da.dims}
         for name in dim_units.keys():
             units.pop(name)
-        new_obj = conversion.attach_unit_attributes(new_obj, dim_units)
 
-        return conversion.attach_units(new_obj, units)
+        return (
+            self.da.pipe(conversion.strip_unit_attributes)
+            .pipe(conversion.attach_unit_attributes, dim_units)
+            .pipe(conversion.attach_units, units)
+        )
 
     def dequantify(self):
         """

--- a/pint_xarray/accessors.py
+++ b/pint_xarray/accessors.py
@@ -237,7 +237,7 @@ class PintDataArrayAccessor:
             if unit is not None or unit_attribute is not None
         }
 
-        return conversion.strip_unit_attributes(self.da).pipe(
+        return self.da.pipe(conversion.strip_unit_attributes).pipe(
             conversion.attach_units, units
         )
 
@@ -493,7 +493,6 @@ class PintDatasetAccessor:
         registry = get_registry(unit_registry, units, conversion.extract_units(self.ds))
 
         unit_attrs = conversion.extract_unit_attributes(self.ds)
-        new_obj = conversion.strip_unit_attributes(self.ds)
 
         units = {
             name: _decide_units(unit, registry, attr)
@@ -501,7 +500,9 @@ class PintDatasetAccessor:
             if unit is not None or attr is not None
         }
 
-        return conversion.attach_units(new_obj, units)
+        return self.ds.pipe(conversion.strip_unit_attributes).pipe(
+            conversion.attach_units, units
+        )
 
     def dequantify(self):
         """

--- a/pint_xarray/accessors.py
+++ b/pint_xarray/accessors.py
@@ -237,15 +237,8 @@ class PintDataArrayAccessor:
             if unit is not None or unit_attribute is not None
         }
 
-        # TODO: remove once indexes support units
-        dim_units = {name: unit for name, unit in units.items() if name in self.da.dims}
-        for name in dim_units.keys():
-            units.pop(name)
-
-        return (
-            self.da.pipe(conversion.strip_unit_attributes)
-            .pipe(conversion.attach_unit_attributes, dim_units)
-            .pipe(conversion.attach_units, units)
+        return conversion.strip_unit_attributes(self.da).pipe(
+            conversion.attach_units, units
         )
 
     def dequantify(self):

--- a/pint_xarray/accessors.py
+++ b/pint_xarray/accessors.py
@@ -255,12 +255,14 @@ class PintDataArrayAccessor:
             that was previously wrapped by `pint.Quantity`.
         """
 
-        units = units_to_str_or_none(conversion.extract_units(self.da))
-        new_obj = conversion.attach_unit_attributes(
-            conversion.strip_units(self.da), units
-        )
+        units = conversion.extract_unit_attributes(self.da)
+        units.update(conversion.extract_units(self.da))
 
-        return new_obj
+        return (
+            self.da.pipe(conversion.strip_units)
+            .pipe(conversion.strip_unit_attributes)
+            .pipe(conversion.attach_unit_attributes, units_to_str_or_none(units))
+        )
 
     @property
     def magnitude(self):

--- a/pint_xarray/conversion.py
+++ b/pint_xarray/conversion.py
@@ -196,10 +196,15 @@ def convert_units(obj, units):
 
 def extract_units(obj):
     if isinstance(obj, Dataset):
-        units = {
-            name: array_extract_units(value.data)
-            for name, value in obj.variables.items()
-        }
+        units = extract_unit_attributes(obj)
+        dims = obj.dims
+        units.update(
+            {
+                name: array_extract_units(value.data)
+                for name, value in obj.variables.items()
+                if name not in dims
+            }
+        )
     elif isinstance(obj, DataArray):
         original_name = obj.name
         name = obj.name if obj.name is not None else "<this-array>"

--- a/pint_xarray/conversion.py
+++ b/pint_xarray/conversion.py
@@ -176,9 +176,6 @@ def convert_units_variable(variable, units):
 
 
 def convert_units(obj, units):
-    if not isinstance(units, dict):
-        units = {None: units}
-
     if isinstance(obj, DataArray):
         original_name = obj.name
         name = obj.name if obj.name is not None else "<this-array>"

--- a/pint_xarray/conversion.py
+++ b/pint_xarray/conversion.py
@@ -148,8 +148,6 @@ def attach_unit_attributes(obj, units, attr="units"):
                 continue
 
             var.attrs[attr] = unit
-    elif isinstance(obj, Variable):
-        new_obj.attrs[attr] = units.get(None)
     else:
         raise ValueError(f"cannot attach unit attributes to {obj!r}: unknown type")
 

--- a/pint_xarray/tests/test_conversion.py
+++ b/pint_xarray/tests/test_conversion.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pint
 import pytest
-from xarray import DataArray, Dataset, Variable
+from xarray import DataArray, Dataset
 
 from pint_xarray import conversion
 
@@ -453,9 +453,6 @@ class TestXarrayFunctions:
                 {"a": "K", "b": "hPa", "x": "m", "u": "s"},
                 id="Dataset",
             ),
-            pytest.param(
-                Variable("x", [], {"units": "hPa"}), {None: "hPa"}, id="Variable"
-            ),
         ),
     )
     def test_extract_unit_attributes(self, obj, expected):
@@ -463,15 +460,15 @@ class TestXarrayFunctions:
         assert expected == actual
 
     @pytest.mark.parametrize(
-        "obj",
+        ["obj", "expected"],
         (
-            pytest.param(Variable("x", [0, 4, 3] * unit_registry.m), id="Variable"),
             pytest.param(
                 DataArray(
                     dims="x",
                     data=[0, 4, 3] * unit_registry.m,
                     coords={"u": ("x", [2, 3, 4] * unit_registry.s)},
                 ),
+                {None: None, "u": None},
                 id="DataArray",
             ),
             pytest.param(
@@ -482,21 +479,14 @@ class TestXarrayFunctions:
                     },
                     coords={"u": ("x", [2, 3, 4] * unit_registry.s)},
                 ),
+                {"a": None, "b": None, "u": None},
                 id="Dataset",
             ),
         ),
     )
-    def test_strip_units(self, obj):
-        if isinstance(obj, Variable):
-            expected_units = {None: None}
-        elif isinstance(obj, DataArray):
-            expected_units = {None: None}
-            expected_units.update({name: None for name in obj.coords.keys()})
-        elif isinstance(obj, Dataset):
-            expected_units = {name: None for name in obj.variables.keys()}
-
+    def test_strip_units(self, obj, expected):
         actual = conversion.strip_units(obj)
-        assert conversion.extract_units(actual) == expected_units
+        assert conversion.extract_units(actual) == expected
 
     @pytest.mark.parametrize(
         ["obj", "expected"],
@@ -526,9 +516,6 @@ class TestXarrayFunctions:
                 ),
                 {"a": "K", "b": "hPa", "x": "m", "u": "s"},
                 id="Dataset",
-            ),
-            pytest.param(
-                Variable("x", [], {"units": "hPa"}), {None: "hPa"}, id="Variable"
             ),
         ),
     )

--- a/pint_xarray/tests/test_conversion.py
+++ b/pint_xarray/tests/test_conversion.py
@@ -185,28 +185,23 @@ class TestXarrayFunctions:
         actual = conversion.attach_units(obj, units)
         assert_identical(actual, expected)
 
-    @pytest.mark.parametrize(
-        ["obj", "units"],
-        (
-            pytest.param(
-                DataArray(dims="x", coords={"x": [], "u": ("x", [])}),
-                {None: "hPa", "x": "m"},
-                id="DataArray",
-            ),
-            pytest.param(
-                Dataset(
-                    data_vars={"a": ("x", []), "b": ("x", [])},
-                    coords={"x": [], "u": ("x", [])},
-                ),
-                {"a": "K", "b": "hPa", "u": "m"},
-                id="Dataset",
-            ),
-            pytest.param(Variable("x", []), {None: "hPa"}, id="Variable"),
-        ),
-    )
-    def test_attach_unit_attributes(self, obj, units):
+    @pytest.mark.parametrize("type", ("DataArray", "Dataset"))
+    def test_attach_unit_attributes(self, type):
+        units = {"a": "K", "b": "hPa", "u": "m", "x": "s"}
+        obj = Dataset(
+            data_vars={"a": ("x", []), "b": ("x", [])},
+            coords={"x": [], "u": ("x", [])},
+        )
+        expected = Dataset(
+            {"a": ("x", [], {"units": "K"}), "b": ("x", [], {"units": "hPa"})},
+            coords={"x": ("x", [], {"units": "s"}), "u": ("x", [], {"units": "m"})},
+        )
+        if type == "DataArray":
+            obj = obj["a"]
+            expected = expected["a"]
+
         actual = conversion.attach_unit_attributes(obj, units)
-        assert units == filter_none_values(conversion.extract_unit_attributes(actual))
+        assert_identical(actual, expected)
 
     @pytest.mark.parametrize(
         "variant",

--- a/pint_xarray/tests/test_conversion.py
+++ b/pint_xarray/tests/test_conversion.py
@@ -18,13 +18,6 @@ def filter_none_values(mapping):
 
 class TestArrayFunctions:
     @pytest.mark.parametrize(
-        "registry",
-        (
-            pytest.param(None, id="without registry"),
-            pytest.param(unit_registry, id="with registry"),
-        ),
-    )
-    @pytest.mark.parametrize(
         "unit",
         (
             pytest.param(1, id="not a unit"),
@@ -40,24 +33,22 @@ class TestArrayFunctions:
             pytest.param(np.array([1, 2]) * unit_registry.m, id="quantity"),
         ),
     )
-    def test_array_attach_units(self, data, unit, registry):
-        if unit == 1:
+    def test_array_attach_units(self, data, unit):
+        if unit == 1 or isinstance(unit, str):
             match = "cannot use .+ as a unit"
         elif isinstance(data, pint.Quantity) and unit is not None:
             match = "already has units"
-        elif isinstance(unit, str) and registry is None:
-            match = "a string as unit"
         else:
             match = None
 
         if match is not None:
             with pytest.raises(ValueError, match=match):
-                conversion.array_attach_units(data, unit, registry=registry)
+                conversion.array_attach_units(data, unit)
 
             return
 
         expected = unit_registry.Quantity(data, "m") if unit is not None else data
-        actual = conversion.array_attach_units(data, unit, registry=registry)
+        actual = conversion.array_attach_units(data, unit)
 
         assert_array_units_equal(expected, actual)
         assert_array_equal(expected, actual)

--- a/pint_xarray/tests/test_conversion.py
+++ b/pint_xarray/tests/test_conversion.py
@@ -110,7 +110,7 @@ class TestArrayFunctions:
         "data",
         (
             pytest.param(np.array([0, 1]), id="array_like"),
-            pytest.param(np.array([1, 2]) * unit_registry.m, id="quantity"),
+            pytest.param(Quantity([1, 2], "m"), id="quantity"),
         ),
     )
     def test_array_extract_units(self, data):
@@ -123,7 +123,7 @@ class TestArrayFunctions:
         "data",
         (
             pytest.param(np.array([1, 2]), id="array_like"),
-            pytest.param(np.array([1, 2]) * unit_registry.m, id="quantity"),
+            pytest.param(Quantity([1, 2], "m"), id="quantity"),
         ),
     )
     def test_array_strip_units(self, data):

--- a/pint_xarray/tests/test_conversion.py
+++ b/pint_xarray/tests/test_conversion.py
@@ -101,6 +101,14 @@ class TestArrayFunctions:
                 id="no unit (None)-ndarray",
             ),
             pytest.param(
+                "mm",
+                np.array([0, 1, 2]),
+                None,
+                ValueError,
+                "cannot convert a non-quantity using .+ as unit",
+                id="string-ndarray",
+            ),
+            pytest.param(
                 Unit("deg"),
                 np.array([0, np.pi / 2, np.pi]),
                 Quantity([0, 90, 180], "deg"),
@@ -109,12 +117,12 @@ class TestArrayFunctions:
                 id="dimensionless-ndarray",
             ),
             pytest.param(
-                "mm",
-                np.array([0, 1, 2]),
+                Unit("mm"),
+                np.array([0, np.pi / 2, np.pi]),
                 None,
-                ValueError,
-                "cannot convert a non-quantity using .+ as unit",
-                id="string-ndarray",
+                pint.DimensionalityError,
+                None,
+                id="unit-ndarray",
             ),
             pytest.param(
                 "mm",

--- a/pint_xarray/tests/test_conversion.py
+++ b/pint_xarray/tests/test_conversion.py
@@ -74,57 +74,74 @@ class TestArrayFunctions:
         assert_array_equal(expected, actual)
 
     @pytest.mark.parametrize(
-        ["unit", "data", "error", "match"],
+        ["unit", "data", "expected", "error", "match"],
         (
             pytest.param(
-                1.2, np.array([0, 1, 2]), ValueError, "", id="not a unit-ndarray"
+                1.2,
+                np.array([0, 1, 2]),
+                None,
+                ValueError,
+                "cannot use .+ as a unit",
+                id="not a unit-ndarray",
             ),
             pytest.param(
                 1,
                 np.array([0, 1, 2]),
+                None,
                 ValueError,
                 "cannot use .+ as a unit",
                 id="no unit (1)-ndarray",
             ),
             pytest.param(
-                None, np.array([0, 1, 2]), None, None, id="no unit (None)-ndarray"
+                None,
+                np.array([0, 1, 2]),
+                np.array([0, 1, 2]),
+                None,
+                None,
+                id="no unit (None)-ndarray",
             ),
             pytest.param(
                 "mm",
                 np.array([0, 1, 2]),
+                None,
                 ValueError,
                 "cannot convert a non-quantity using .+ as unit",
                 id="string-ndarray",
             ),
             pytest.param(
-                "mm", Quantity([0, 1, 2], "m"), None, None, id="string-quantity"
+                "mm",
+                Quantity([0, 1, 2], "m"),
+                Quantity([0, 1000, 2000], "mm"),
+                None,
+                None,
+                id="string-quantity",
             ),
             pytest.param(
-                unit_registry.mm, Quantity([0, 1, 2], "m"), None, None, id="unit object"
+                unit_registry.mm,
+                Quantity([0, 1, 2], "m"),
+                Quantity([0, 1000, 2000], "mm"),
+                None,
+                None,
+                id="unit object",
             ),
             pytest.param(
                 "s",
                 Quantity([0, 1, 2], "m"),
+                None,
                 pint.DimensionalityError,
                 None,
                 id="quantity-incompatible unit",
             ),
         ),
     )
-    def test_array_convert_units(self, data, unit, error, match):
+    def test_array_convert_units(self, data, unit, expected, error, match):
         if error is not None:
             with pytest.raises(error, match=match):
                 conversion.array_convert_units(data, unit)
 
             return
 
-        expected = (
-            unit_registry.Quantity(np.array([0, 1000, 2000]), "mm")
-            if unit is not None
-            else data
-        )
         actual = conversion.array_convert_units(data, unit)
-
         assert_array_equal(expected, actual)
 
     @pytest.mark.parametrize(

--- a/pint_xarray/tests/test_conversion.py
+++ b/pint_xarray/tests/test_conversion.py
@@ -29,6 +29,9 @@ def convert_quantity(q, u):
     if u is None:
         return q
 
+    if not isinstance(q, Quantity):
+        q = Quantity(q)
+
     return q.to(u)
 
 

--- a/pint_xarray/tests/test_conversion.py
+++ b/pint_xarray/tests/test_conversion.py
@@ -18,29 +18,26 @@ def filter_none_values(mapping):
 
 class TestArrayFunctions:
     @pytest.mark.parametrize(
-        "unit",
+        ["unit", "data", "match"],
         (
-            pytest.param(1, id="not a unit"),
-            pytest.param(None, id="no unit"),
-            pytest.param("m", id="string"),
-            pytest.param(unit_registry.m, id="unit object"),
+            pytest.param(
+                1.2, np.array([0, 1]), "cannot use .+ as a unit", id="not a unit"
+            ),
+            pytest.param(
+                1, np.array([0, 1]), "cannot use .+ as a unit", id="no unit (1)"
+            ),
+            pytest.param(None, np.array([0, 1]), None, id="no unit (None)"),
+            pytest.param("m", np.array([0, 1]), "cannot use .+ as a unit", id="string"),
+            pytest.param(unit_registry.m, np.array([0, 1]), None, id="unit object"),
+            pytest.param(
+                unit_registry.m,
+                unit_registry.Quantity(np.array([0, 1]), "s"),
+                "already has units",
+                id="unit object on quantity",
+            ),
         ),
     )
-    @pytest.mark.parametrize(
-        "data",
-        (
-            pytest.param(np.array([0, 1]), id="array_like"),
-            pytest.param(np.array([1, 2]) * unit_registry.m, id="quantity"),
-        ),
-    )
-    def test_array_attach_units(self, data, unit):
-        if unit == 1 or isinstance(unit, str):
-            match = "cannot use .+ as a unit"
-        elif isinstance(data, pint.Quantity) and unit is not None:
-            match = "already has units"
-        else:
-            match = None
-
+    def test_array_attach_units(self, data, unit, match):
         if match is not None:
             with pytest.raises(ValueError, match=match):
                 conversion.array_attach_units(data, unit)

--- a/pint_xarray/tests/test_conversion.py
+++ b/pint_xarray/tests/test_conversion.py
@@ -101,6 +101,14 @@ class TestArrayFunctions:
                 id="no unit (None)-ndarray",
             ),
             pytest.param(
+                Unit("deg"),
+                np.array([0, np.pi / 2, np.pi]),
+                Quantity([0, 90, 180], "deg"),
+                None,
+                None,
+                id="dimensionless-ndarray",
+            ),
+            pytest.param(
                 "mm",
                 np.array([0, 1, 2]),
                 None,

--- a/pint_xarray/tests/test_conversion.py
+++ b/pint_xarray/tests/test_conversion.py
@@ -257,7 +257,7 @@ class TestXarrayFunctions:
             pytest.param(
                 "none",
                 {"a": Unit("g"), "b": Unit("Pa"), "u": Unit("ms"), "x": Unit("mm")},
-                None,
+                pint.DimensionalityError,
                 None,
                 id="none-with units",
             ),
@@ -272,7 +272,7 @@ class TestXarrayFunctions:
             pytest.param(
                 "data",
                 {"a": Unit("s"), "b": Unit("m")},
-                None,
+                pint.DimensionalityError,
                 None,
                 id="data-incompatible units",
             ),
@@ -293,7 +293,7 @@ class TestXarrayFunctions:
             pytest.param(
                 "dims",
                 {"x": Unit("ms")},
-                None,
+                pint.DimensionalityError,
                 None,
                 id="dims-incompatible units",
             ),
@@ -314,7 +314,7 @@ class TestXarrayFunctions:
             pytest.param(
                 "coords",
                 {"u": Unit("mm")},
-                None,
+                pint.DimensionalityError,
                 None,
                 id="coords-incompatible units",
             ),
@@ -349,6 +349,13 @@ class TestXarrayFunctions:
                 "x": ("x", x, {"units": original_units.get("x")}),
             },
         )
+
+        if error is not None:
+            with pytest.raises(error, match=match):
+                conversion.convert_units(obj, units)
+
+            return
+
         expected = Dataset(
             {
                 "a": (

--- a/pint_xarray/tests/utils.py
+++ b/pint_xarray/tests/utils.py
@@ -3,9 +3,9 @@ from contextlib import contextmanager
 
 import numpy as np
 import pytest
-import xarray as xr
-from pint.quantity import Quantity
 from xarray.testing import assert_equal, assert_identical  # noqa: F401
+
+from ..conversion import extract_units
 
 
 @contextmanager
@@ -18,79 +18,6 @@ def raises_regex(error, pattern):
         raise AssertionError(
             f"exception {excinfo.value!r} did not match pattern {pattern!r}"
         )
-
-
-def array_extract_units(obj):
-    if isinstance(obj, (xr.Variable, xr.DataArray, xr.Dataset)):
-        obj = obj.data
-
-    try:
-        return obj.units
-    except AttributeError:
-        return None
-
-
-def extract_units(obj):
-    if isinstance(obj, xr.Dataset):
-        vars_units = {
-            name: array_extract_units(value) for name, value in obj.data_vars.items()
-        }
-        coords_units = {
-            name: array_extract_units(value) for name, value in obj.coords.items()
-        }
-
-        units = {**vars_units, **coords_units}
-    elif isinstance(obj, xr.DataArray):
-        vars_units = {obj.name: array_extract_units(obj)}
-        coords_units = {
-            name: array_extract_units(value) for name, value in obj.coords.items()
-        }
-
-        units = {**vars_units, **coords_units}
-    elif isinstance(obj, xr.Variable):
-        vars_units = {None: array_extract_units(obj.data)}
-
-        units = {**vars_units}
-    elif isinstance(obj, Quantity):
-        vars_units = {None: array_extract_units(obj)}
-
-        units = {**vars_units}
-    else:
-        units = {}
-
-    return units
-
-
-def attach_units(obj, units):
-    if isinstance(obj, xr.DataArray):
-        ds = obj._to_temp_dataset()
-        new_name = list(ds.data_vars.keys())[0]
-        units[new_name] = units.get(obj.name)
-        new_ds = attach_units(ds, units)
-        new_obj = obj._from_temp_dataset(new_ds)
-    elif isinstance(obj, xr.Dataset):
-        data_vars = {
-            name: attach_units(array.variable, {None: units.get(name)})
-            for name, array in obj.data_vars.items()
-        }
-
-        coords = {
-            name: attach_units(array.variable, {None: units.get(name)})
-            for name, array in obj.coords.items()
-        }
-
-        new_obj = xr.Dataset(data_vars=data_vars, coords=coords, attrs=obj.attrs)
-    elif isinstance(obj, xr.Variable):
-        new_data = attach_units(obj.data, units)
-        new_obj = obj.copy(data=new_data)
-    elif isinstance(obj, Quantity):
-        raise ValueError(
-            f"cannot attach {units.get(None)} to {obj}: already a quantity"
-        )
-    else:
-        new_obj = Quantity(obj, units.get(None))
-
-    return new_obj
 
 
 def assert_array_units_equal(a, b):

--- a/pint_xarray/tests/utils.py
+++ b/pint_xarray/tests/utils.py
@@ -5,7 +5,7 @@ import numpy as np
 import pytest
 import xarray as xr
 from pint.quantity import Quantity
-from xarray.testing import assert_equal  # noqa: F401
+from xarray.testing import assert_equal, assert_identical  # noqa: F401
 
 
 @contextmanager


### PR DESCRIPTION
While looking at the code in the last few days I realized that some of the functions are unnecessarily complex, resulting in a reduced test coverage. This refactors these functions and adds the capability to quantify / convert / dequantify dimension coordinates (no automatic unit conversion, though, that still depends on the indexing refactor for xarray).