### PR TITLE
sel

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -16,6 +16,7 @@ Dataset
    xarray.Dataset.pint.quantify
    xarray.Dataset.pint.dequantify
    xarray.Dataset.pint.to
+   xarray.Dataset.pint.sel
 
 DataArray
 ---------
@@ -35,6 +36,7 @@ DataArray
    xarray.DataArray.pint.quantify
    xarray.DataArray.pint.dequantify
    xarray.DataArray.pint.to
+   xarray.DataArray.pint.sel
 
 Testing
 -------

--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -7,12 +7,17 @@ What's new
 ------------------
 - rewrite :py:meth:`Dataset.pint.quantify` and :py:meth:`DataArray.pint.quantify`,
   to use pint's `parse_units` instead of `parse_expression` (:pull:`40`)
+  By `Tom Nicholas <https://github.com/TomNicholas>`_.
 - refactor the internal conversion functions (:pull:`56`)
+  By `Justus Magin <https://github.com/keewis>`_.
 - allow converting indexes (except :py:class:`pandas.MultiIndex`) (:pull:`56`)
+  By `Justus Magin <https://github.com/keewis>`_.
 - document the reason for requiring the ``force_ndarray_like`` or ``force_ndarray``
   options on unit registries (:pull:`59`)
+  By `Justus Magin <https://github.com/keewis>`_.
 - allow passing a format string to :py:meth:`Dataset.pint.dequantify` and
   :py:meth:`DataArray.pint.dequantify` (:pull:`49`)
+  By `Justus Magin <https://github.com/keewis>`_.
 - allow converting all data variables in a Dataset to the same units using
   :py:meth:`Dataset.pint.to` (:issue:`45`, :pull:`63`).
   By `Mika Pflüger <https://github.com/mikapfl>`_.

--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -18,6 +18,8 @@ What's new
   By `Mika Pflüger <https://github.com/mikapfl>`_.
 - update format of examples in docstrings (:pull:`64`).
   By `Mika Pflüger <https://github.com/mikapfl>`_.
+- implement :py:meth:`Dataset.pint.sel` and :py:meth:`DataArray.pint.sel` (:pull:`60`).
+  By `Justus Magin <https://github.com/keewis>`_.
 
 v0.1 (October 26 2020)
 ----------------------

--- a/pint_xarray/accessors.py
+++ b/pint_xarray/accessors.py
@@ -432,6 +432,8 @@ class PintDataArrayAccessor:
             for name, indexer in indexers.items()
         }
 
+        # TODO: handle tolerance
+
         # make sure we only have compatible units
         dims = self.da.dims
         unit_attrs = conversion.extract_unit_attributes(self.da)
@@ -766,6 +768,8 @@ class PintDatasetAccessor:
             name: conversion.extract_indexer_units(indexer)
             for name, indexer in indexers.items()
         }
+
+        # TODO: handle tolerance
 
         # make sure we only have compatible units
         dims = self.ds.dims

--- a/pint_xarray/accessors.py
+++ b/pint_xarray/accessors.py
@@ -7,6 +7,7 @@ from pint.unit import Unit
 from xarray import register_dataarray_accessor, register_dataset_accessor
 
 from . import conversion
+from .errors import DimensionalityError
 
 
 def setup_registry(registry):
@@ -642,7 +643,51 @@ class PintDatasetAccessor:
     def sel(
         self, indexers=None, method=None, tolerance=None, drop=False, **indexers_kwargs
     ):
-        ...
+        indexers = either_dict_or_kwargs(indexers, indexers_kwargs, "sel")
+
+        dims = self.ds.dims
+        unit_attrs = conversion.extract_unit_attributes(self.ds)
+        index_units = {
+            name: units for name, units in unit_attrs.items() if name in dims
+        }
+        indexers_units = {
+            name: conversion.extract_indexer_units(indexer)
+            for name, indexer in indexers.items()
+        }
+        units = zip_mappings(indexers_units, index_units)
+
+        registry = get_registry(None, index_units, indexers_units)
+
+        # make sure we only have compatible units
+        incompatible_units = {
+            key: (indexer_unit, index_unit)
+            for key, (indexer_unit, index_unit) in units.items()
+            if (
+                None not in (indexer_unit, index_unit)
+                and not registry.is_compatible_with(indexer_unit, index_unit)
+            )
+        }
+        if incompatible_units:
+            units1 = {key: value for key, (value, _) in incompatible_units.items()}
+            units2 = {key: value for key, (_, value) in incompatible_units.items()}
+            raise DimensionalityError(units1, units2)
+
+        # convert the indexes to the indexer's units
+        converted = conversion.convert_units(self.ds, indexers_units)
+
+        # index
+        stripped_indexers = {
+            name: conversion.strip_indexer_units(indexer)
+            for name, indexer in indexers.items()
+        }
+        indexed = converted.sel(
+            stripped_indexers,
+            method=method,
+            tolerance=tolerance,
+            drop=drop,
+        )
+
+        return indexed
 
     @property
     def loc(self):

--- a/pint_xarray/accessors.py
+++ b/pint_xarray/accessors.py
@@ -643,6 +643,15 @@ class PintDatasetAccessor:
     def sel(
         self, indexers=None, method=None, tolerance=None, drop=False, **indexers_kwargs
     ):
+        """unit-aware version of sel
+
+        Just like ``Dataset.sel``, except the dataset's indexes are converted to the units
+        of the indexers first.
+
+        .. note::
+            ``tolerance`` is not supported, yet. It will be passed through to
+            ``Dataset.sel`` unmodified.
+        """
         indexers = either_dict_or_kwargs(indexers, indexers_kwargs, "sel")
 
         dims = self.ds.dims

--- a/pint_xarray/accessors.py
+++ b/pint_xarray/accessors.py
@@ -654,19 +654,20 @@ class PintDatasetAccessor:
         """
         indexers = either_dict_or_kwargs(indexers, indexers_kwargs, "sel")
 
-        dims = self.ds.dims
-        unit_attrs = conversion.extract_unit_attributes(self.ds)
-        index_units = {
-            name: units for name, units in unit_attrs.items() if name in dims
-        }
         indexer_units = {
             name: conversion.extract_indexer_units(indexer)
             for name, indexer in indexers.items()
         }
 
+        # make sure we only have compatible units
+        dims = self.ds.dims
+        unit_attrs = conversion.extract_unit_attributes(self.ds)
+        index_units = {
+            name: units for name, units in unit_attrs.items() if name in dims
+        }
+
         registry = get_registry(None, index_units, indexer_units)
 
-        # make sure we only have compatible units
         units = zip_mappings(indexer_units, index_units)
         incompatible_units = [
             key

--- a/pint_xarray/accessors.py
+++ b/pint_xarray/accessors.py
@@ -645,12 +645,18 @@ class PintDatasetAccessor:
     ):
         """unit-aware version of sel
 
-        Just like ``Dataset.sel``, except the dataset's indexes are converted to the units
+        Just like :py:meth:`xarray.Dataset.sel`, except the dataset's indexes are converted to the units
         of the indexers first.
 
         .. note::
             ``tolerance`` is not supported, yet. It will be passed through to
             ``Dataset.sel`` unmodified.
+
+        See Also
+        --------
+        xarray.DataArray.pint.sel
+        xarray.Dataset.sel
+        xarray.DataArray.sel
         """
         indexers = either_dict_or_kwargs(indexers, indexers_kwargs, "sel")
 

--- a/pint_xarray/accessors.py
+++ b/pint_xarray/accessors.py
@@ -659,30 +659,30 @@ class PintDatasetAccessor:
         index_units = {
             name: units for name, units in unit_attrs.items() if name in dims
         }
-        indexers_units = {
+        indexer_units = {
             name: conversion.extract_indexer_units(indexer)
             for name, indexer in indexers.items()
         }
-        units = zip_mappings(indexers_units, index_units)
 
-        registry = get_registry(None, index_units, indexers_units)
+        registry = get_registry(None, index_units, indexer_units)
 
         # make sure we only have compatible units
-        incompatible_units = {
-            key: (indexer_unit, index_unit)
+        units = zip_mappings(indexer_units, index_units)
+        incompatible_units = [
+            key
             for key, (indexer_unit, index_unit) in units.items()
             if (
                 None not in (indexer_unit, index_unit)
                 and not registry.is_compatible_with(indexer_unit, index_unit)
             )
-        }
+        ]
         if incompatible_units:
-            units1 = {key: value for key, (value, _) in incompatible_units.items()}
-            units2 = {key: value for key, (_, value) in incompatible_units.items()}
+            units1 = {key: indexer_units[key] for key in incompatible_units}
+            units2 = {key: index_units[key] for key in incompatible_units}
             raise DimensionalityError(units1, units2)
 
         # convert the indexes to the indexer's units
-        converted = conversion.convert_units(self.ds, indexers_units)
+        converted = conversion.convert_units(self.ds, indexer_units)
 
         # index
         stripped_indexers = {

--- a/pint_xarray/accessors.py
+++ b/pint_xarray/accessors.py
@@ -410,7 +410,67 @@ class PintDataArrayAccessor:
     def sel(
         self, indexers=None, method=None, tolerance=None, drop=False, **indexers_kwargs
     ):
-        ...
+        """unit-aware version of sel
+
+        Just like :py:meth:`DataArray.sel`, except the dataset's indexes are converted
+        to the units of the indexers first.
+
+        .. note::
+            ``tolerance`` is not supported, yet. It will be passed through to
+            ``DataArray.sel`` unmodified.
+
+        See Also
+        --------
+        xarray.Dataset.pint.sel
+        xarray.DataArray.sel
+        xarray.Dataset.sel
+        """
+        indexers = either_dict_or_kwargs(indexers, indexers_kwargs, "sel")
+
+        indexer_units = {
+            name: conversion.extract_indexer_units(indexer)
+            for name, indexer in indexers.items()
+        }
+
+        # make sure we only have compatible units
+        dims = self.da.dims
+        unit_attrs = conversion.extract_unit_attributes(self.da)
+        index_units = {
+            name: units for name, units in unit_attrs.items() if name in dims
+        }
+
+        registry = get_registry(None, index_units, indexer_units)
+
+        units = zip_mappings(indexer_units, index_units)
+        incompatible_units = [
+            key
+            for key, (indexer_unit, index_unit) in units.items()
+            if (
+                None not in (indexer_unit, index_unit)
+                and not registry.is_compatible_with(indexer_unit, index_unit)
+            )
+        ]
+        if incompatible_units:
+            units1 = {key: indexer_units[key] for key in incompatible_units}
+            units2 = {key: index_units[key] for key in incompatible_units}
+            raise DimensionalityError(units1, units2)
+
+        # convert the indexes to the indexer's units
+        converted = conversion.convert_units(self.da, indexer_units)
+
+        # index
+        stripped_indexers = {
+            name: conversion.strip_indexer_units(indexer)
+            for name, indexer in indexers.items()
+        }
+        indexed = converted.sel(
+            stripped_indexers,
+            method=method,
+            tolerance=tolerance,
+            drop=drop,
+        )
+
+        return indexed
 
     @property
     def loc(self):

--- a/pint_xarray/conversion.py
+++ b/pint_xarray/conversion.py
@@ -304,35 +304,6 @@ def strip_unit_attributes(obj, attr="units"):
     return new_obj
 
 
-def convert_indexes(obj, units, attr="units"):
-    dims = obj.dims
-    if isinstance(obj, DataArray):
-        variables = itertools.chain([(obj.name, obj)], obj.coords.items())
-    elif isinstance(obj, Dataset):
-        variables = obj.variables.items()
-    else:
-        raise ValueError(f"invalid object: {obj}")
-
-    index_variables = {name: var for name, var in variables if name in dims}
-    index_units = {k: v for k, v in extract_unit_attributes(obj).items() if k in dims}
-    variables = {
-        name: attach_units(
-            strip_unit_attributes(var.to_base_variable()),
-            {None: index_units.get(name)},
-        )
-        for name, var in index_variables.items()
-    }
-    converted = {
-        name: convert_units(var, {None: units.get(name)})
-        for name, var in variables.items()
-    }
-    new_coords = {
-        name: attach_unit_attributes(strip_units(var), extract_units(var))
-        for name, var in converted.items()
-    }
-    return obj.assign_coords(new_coords)
-
-
 def slice_extract_units(indexer):
     elements = {name: getattr(indexer, name) for name in ("start", "stop", "step")}
     extracted_units = [

--- a/pint_xarray/conversion.py
+++ b/pint_xarray/conversion.py
@@ -339,3 +339,18 @@ def extract_indexer_units(indexer):
         return array_extract_units(indexer.data)
     else:
         return array_extract_units(indexer)
+
+
+def strip_indexer_units(indexer):
+    if isinstance(indexer, slice):
+        return slice(
+            array_strip_units(indexer.start),
+            array_strip_units(indexer.stop),
+            array_strip_units(indexer.step),
+        )
+    elif isinstance(indexer, DataArray):
+        return strip_units(indexer)
+    elif isinstance(indexer, Variable):
+        return strip_units_variable(indexer)
+    else:
+        return array_strip_units(indexer)

--- a/pint_xarray/conversion.py
+++ b/pint_xarray/conversion.py
@@ -281,3 +281,32 @@ def strip_unit_attributes(obj, attr="units"):
         )
 
     return new_obj
+
+
+def convert_indexes(obj, units, attr="units"):
+    dims = obj.dims
+    if isinstance(obj, DataArray):
+        variables = itertools.chain([(obj.name, obj)], obj.coords.items())
+    elif isinstance(obj, Dataset):
+        variables = obj.variables.items()
+    else:
+        raise ValueError(f"invalid object: {obj}")
+
+    index_variables = {name: var for name, var in variables if name in dims}
+    index_units = {k: v for k, v in extract_unit_attributes(obj).items() if k in dims}
+    variables = {
+        name: attach_units(
+            strip_unit_attributes(var.to_base_variable()),
+            {None: index_units.get(name)},
+        )
+        for name, var in index_variables.items()
+    }
+    converted = {
+        name: convert_units(var, {None: units.get(name)})
+        for name, var in variables.items()
+    }
+    new_coords = {
+        name: attach_unit_attributes(strip_units(var), extract_units(var))
+        for name, var in converted.items()
+    }
+    return obj.assign_coords(new_coords)

--- a/pint_xarray/conversion.py
+++ b/pint_xarray/conversion.py
@@ -194,13 +194,14 @@ def convert_units(obj, units):
             for name, variable in obj.variables.items()
             if name in obj._coord_names
         }
+
         data_vars = {
             name: convert_units_variable(variable, units.get(name))
             for name, variable in obj.variables.items()
             if name not in obj._coord_names
         }
 
-        new_obj = Dataset(coords=coords, data_vars=data_vars, attrs=obj.attrs)
+        new_obj = Dataset(data_vars=data_vars, coords=coords, attrs=obj.attrs)
     else:
         raise ValueError(f"cannot convert object: {obj}")
 

--- a/pint_xarray/errors.py
+++ b/pint_xarray/errors.py
@@ -1,0 +1,43 @@
+import pint
+
+
+class DimensionalityError(pint.DimensionalityError):
+    """Raised when trying to convert between incompatible units
+
+    Parameters
+    ----------
+    units1 : mapping of hashable to unit-like
+        The units of the existing object which are incompatible with the new units.
+    units2 : mapping of hashable to unit-like
+        The units to convert the object to which are incompatible with the existing
+        units.
+    """
+
+    def __init__(self, units1, units2):
+        if units1.keys() != units2.keys():
+            raise ValueError("units1 and units2 must have the same keys")
+        elif not units1:
+            raise ValueError("no units given")
+
+        self.incompatible_units = {
+            key: (units1[key], units2[key]) for key in units1.keys()
+        }
+
+    def __str__(self):
+        incompatible_units = self.incompatible_units
+
+        message = "Cannot convert some variables:"
+        if len(incompatible_units) == 1:
+            sep = ""
+            message += " "
+        else:
+            sep = "\n -- "
+
+        message = sep.join(
+            [message]
+            + [
+                f"incompatible units for {key}: {u1.dimensionality} != {u2.dimensionality}"
+                for key, (u1, u2) in incompatible_units.items()
+            ]
+        )
+        return message

--- a/pint_xarray/tests/test_accessors.py
+++ b/pint_xarray/tests/test_accessors.py
@@ -335,7 +335,7 @@ class TestDequantifyDataSet:
             ),
             {"x": Quantity([10, 30], "dm"), "y": Quantity([60], "s")},
             xr.DataArray(
-                [[0], [2]],
+                [[0], [4]],
                 dims=("x", "y"),
                 coords={
                     "x": ("x", [10, 30], {"units": unit_registry.Unit("dm")}),
@@ -356,7 +356,7 @@ class TestDequantifyDataSet:
             ),
             {"x": Quantity([1, 3], "m"), "y": Quantity([1], "min")},
             xr.DataArray(
-                [[0], [2]],
+                [[0], [4]],
                 dims=("x", "y"),
                 coords={
                     "x": ("x", [1, 3], {"units": unit_registry.Unit("m")}),
@@ -375,16 +375,9 @@ class TestDequantifyDataSet:
                     "y": ("y", [60, 120], {"units": unit_registry.Unit("s")}),
                 },
             ),
-            {"x": Quantity([10, 30], "dm"), "y": Quantity([60], "s")},
-            xr.DataArray(
-                [[0], [2]],
-                dims=("x", "y"),
-                coords={
-                    "x": ("x", [10, 30], {"units": unit_registry.Unit("dm")}),
-                    "y": ("y", [60], {"units": unit_registry.Unit("s")}),
-                },
-            ),
+            {"x": Quantity([10, 30], "s"), "y": Quantity([60], "m")},
             None,
+            DimensionalityError,
             id="DataArray-incompatible units",
         ),
     ),

--- a/pint_xarray/tests/test_accessors.py
+++ b/pint_xarray/tests/test_accessors.py
@@ -4,10 +4,10 @@ import xarray as xr
 from numpy.testing import assert_array_equal
 from pint import Unit, UnitRegistry
 from pint.errors import UndefinedUnitError
-from xarray.testing import assert_equal
 
 from .. import accessors, conversion
-from .utils import raises_regex
+from ..errors import DimensionalityError
+from .utils import assert_equal, assert_identical, assert_units_equal, raises_regex
 
 pytestmark = [
     pytest.mark.filterwarnings("error::pint.UnitStrippedWarning"),
@@ -273,3 +273,127 @@ class TestDequantifyDataSet:
 
         result = quantified.pint.dequantify().pint.quantify()
         assert_equal(quantified, result)
+
+
+@pytest.mark.parametrize(
+    ["obj", "indexers", "expected", "error"],
+    (
+        pytest.param(
+            xr.Dataset(
+                {
+                    "x": ("x", [10, 20, 30], {"units": unit_registry.Unit("dm")}),
+                    "y": ("y", [60, 120], {"units": unit_registry.Unit("s")}),
+                }
+            ),
+            {"x": Quantity([10, 30], "dm"), "y": Quantity([60], "s")},
+            xr.Dataset(
+                {
+                    "x": ("x", [10, 30], {"units": unit_registry.Unit("dm")}),
+                    "y": ("y", [60], {"units": unit_registry.Unit("s")}),
+                }
+            ),
+            None,
+            id="Dataset-identical units",
+        ),
+        pytest.param(
+            xr.Dataset(
+                {
+                    "x": ("x", [10, 20, 30], {"units": unit_registry.Unit("dm")}),
+                    "y": ("y", [60, 120], {"units": unit_registry.Unit("s")}),
+                }
+            ),
+            {"x": Quantity([1, 3], "m"), "y": Quantity([1], "min")},
+            xr.Dataset(
+                {
+                    "x": ("x", [1, 3], {"units": unit_registry.Unit("m")}),
+                    "y": ("y", [1], {"units": unit_registry.Unit("min")}),
+                }
+            ),
+            None,
+            id="Dataset-compatible units",
+        ),
+        pytest.param(
+            xr.Dataset(
+                {
+                    "x": ("x", [10, 20, 30], {"units": unit_registry.Unit("dm")}),
+                    "y": ("y", [60, 120], {"units": unit_registry.Unit("s")}),
+                }
+            ),
+            {"x": Quantity([1, 3], "s"), "y": Quantity([1], "m")},
+            None,
+            DimensionalityError,
+            id="Dataset-incompatible units",
+        ),
+        pytest.param(
+            xr.DataArray(
+                [[0, 1], [2, 3], [4, 5]],
+                dims=("x", "y"),
+                coords={
+                    "x": ("x", [10, 20, 30], {"units": unit_registry.Unit("dm")}),
+                    "y": ("y", [60, 120], {"units": unit_registry.Unit("s")}),
+                },
+            ),
+            {"x": Quantity([10, 30], "dm"), "y": Quantity([60], "s")},
+            xr.DataArray(
+                [[0], [2]],
+                dims=("x", "y"),
+                coords={
+                    "x": ("x", [10, 30], {"units": unit_registry.Unit("dm")}),
+                    "y": ("y", [60], {"units": unit_registry.Unit("s")}),
+                },
+            ),
+            None,
+            id="DataArray-identical units",
+        ),
+        pytest.param(
+            xr.DataArray(
+                [[0, 1], [2, 3], [4, 5]],
+                dims=("x", "y"),
+                coords={
+                    "x": ("x", [10, 20, 30], {"units": unit_registry.Unit("dm")}),
+                    "y": ("y", [60, 120], {"units": unit_registry.Unit("s")}),
+                },
+            ),
+            {"x": Quantity([1, 3], "m"), "y": Quantity([1], "min")},
+            xr.DataArray(
+                [[0], [2]],
+                dims=("x", "y"),
+                coords={
+                    "x": ("x", [1, 3], {"units": unit_registry.Unit("m")}),
+                    "y": ("y", [1], {"units": unit_registry.Unit("min")}),
+                },
+            ),
+            None,
+            id="DataArray-compatible units",
+        ),
+        pytest.param(
+            xr.DataArray(
+                [[0, 1], [2, 3], [4, 5]],
+                dims=("x", "y"),
+                coords={
+                    "x": ("x", [10, 20, 30], {"units": unit_registry.Unit("dm")}),
+                    "y": ("y", [60, 120], {"units": unit_registry.Unit("s")}),
+                },
+            ),
+            {"x": Quantity([10, 30], "dm"), "y": Quantity([60], "s")},
+            xr.DataArray(
+                [[0], [2]],
+                dims=("x", "y"),
+                coords={
+                    "x": ("x", [10, 30], {"units": unit_registry.Unit("dm")}),
+                    "y": ("y", [60], {"units": unit_registry.Unit("s")}),
+                },
+            ),
+            None,
+            id="DataArray-incompatible units",
+        ),
+    ),
+)
+def test_sel(obj, indexers, expected, error):
+    if error is not None:
+        with pytest.raises(error):
+            obj.pint.sel(indexers)
+    else:
+        actual = obj.pint.sel(indexers)
+        assert_units_equal(actual, expected)
+        assert_identical(actual, expected)

--- a/pint_xarray/tests/test_conversion.py
+++ b/pint_xarray/tests/test_conversion.py
@@ -546,7 +546,7 @@ class TestXarrayFunctions:
                 Unit("s"),
                 id="DataArray-units",
             ),
-            pytest.param(slice(None), slice(None), id="empty slice-no units"),
+            pytest.param(slice(None), None, id="empty slice-no units"),
             pytest.param(slice(1, None), None, id="slice-no units"),
             pytest.param(
                 slice(Quantity(1, "m"), Quantity(2, "m")),

--- a/pint_xarray/tests/test_conversion.py
+++ b/pint_xarray/tests/test_conversion.py
@@ -582,3 +582,44 @@ class TestXarrayFunctions:
         else:
             actual = conversion.extract_indexer_units(indexer)
             assert actual == expected
+
+    @pytest.mark.parametrize(
+        ["indexer", "expected"],
+        (
+            pytest.param(1, 1, id="scalar-no units"),
+            pytest.param(Quantity(1, "m"), 1, id="scalar-units"),
+            pytest.param(np.array([1, 2]), np.array([1, 2]), id="array-no units"),
+            pytest.param(Quantity([1, 2], "s"), np.array([1, 2]), id="array-units"),
+            pytest.param(
+                Variable("x", [1, 2]), Variable("x", [1, 2]), id="Variable-no units"
+            ),
+            pytest.param(
+                Variable("x", Quantity([1, 2], "m")),
+                Variable("x", [1, 2]),
+                id="Variable-units",
+            ),
+            pytest.param(
+                DataArray([1, 2], dims="x"),
+                DataArray([1, 2], dims="x"),
+                id="DataArray-no units",
+            ),
+            pytest.param(
+                DataArray(Quantity([1, 2], "s"), dims="x"),
+                DataArray([1, 2], dims="x"),
+                id="DataArray-units",
+            ),
+            pytest.param(slice(None), slice(None), id="empty slice-no units"),
+            pytest.param(slice(1, None), slice(1, None), id="slice-no units"),
+            pytest.param(
+                slice(Quantity(1, "m"), Quantity(2, "m")),
+                slice(1, 2),
+                id="slice-units",
+            ),
+        ),
+    )
+    def test_strip_indexer_units(self, indexer, expected):
+        actual = conversion.strip_indexer_units(indexer)
+        if isinstance(indexer, DataArray):
+            assert_identical(actual, expected)
+        else:
+            assert_array_equal(actual, expected)


### PR DESCRIPTION
This is an attempt to implement a unit-aware `Dataset.pint.sel` (no `loc` for now).

Unlike the implementation in MetPy, the current implementation converts the indexes to the units of the indexers. This is usually slower but closer to the implementation of `Dataset.sel`, where the indexers become the new indexes. Not sure if speed is more important, though.

cc @jthielen