### PR TITLE
add a plotting example

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -46,6 +46,7 @@ extensions = [
     "sphinx_autosummary_accessors",
     "IPython.sphinxext.ipython_directive",
     "IPython.sphinxext.ipython_console_highlighting",
+    "nbsphinx",
 ]
 
 # Add any paths that contain templates here, relative to this directory.
@@ -99,6 +100,10 @@ napoleon_type_aliases = {
     # pint / pint-xarray
     "unit-like": ":term:`unit-like`",
 }
+
+# nbsphinx
+nbsphinx_timeout = 600
+nbsphinx_execute = "always"
 
 # -- Options for intersphinx extension ---------------------------------------
 

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -1,3 +1,7 @@
 Examples
 ========
-There are no examples yet.
+
+.. toctree::
+    :maxdepth: 1
+
+    examples/plotting

--- a/docs/examples/plotting.ipynb
+++ b/docs/examples/plotting.ipynb
@@ -1,0 +1,151 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "documentary-giant",
+   "metadata": {},
+   "source": [
+    "# plotting quantified data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "homeless-ballot",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import xarray as xr\n",
+    "import pint_xarray"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "latter-repeat",
+   "metadata": {},
+   "source": [
+    "## load the data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "comprehensive-senegal",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ds = xr.tutorial.open_dataset(\"air_temperature\")\n",
+    "data = ds.air\n",
+    "data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "precious-grocery",
+   "metadata": {},
+   "source": [
+    "## convert units into a format understood by pint\n",
+    "\n",
+    "<!-- Use one of the alert classes: alert-info, alert-warning, alert-success, alert-danger -->\n",
+    "<div class=\"alert alert-block\">\n",
+    "    <b>Note:</b> this example uses the data provided by the <tt>xarray.tutorial</tt> functions. As such, the units attributes follow the CF conventions, which by default <tt>pint</tt> does not understand. To work around that, we're modifying the <tt>units</tt> attributes here, but in general it is better to use a library that modifies the <tt>UnitRegistry</tt>.\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dress-vegetarian",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data.lat.attrs[\"units\"] = \"degree\"\n",
+    "data.lon.attrs[\"units\"] = \"degree\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "convinced-recorder",
+   "metadata": {},
+   "source": [
+    "## quantify the data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "mechanical-animal",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "quantified = data.pint.quantify()\n",
+    "quantified"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "warming-lingerie",
+   "metadata": {},
+   "source": [
+    "## work with the data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "major-enclosure",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "monthly_means = (\n",
+    "    quantified\n",
+    "    .pint.to(\"degC\")\n",
+    "    .sel(time=\"2013\")\n",
+    "    .groupby(\"time.month\").mean()\n",
+    ")\n",
+    "monthly_means"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "expired-chest",
+   "metadata": {},
+   "source": [
+    "## plot\n",
+    "\n",
+    "`xarray`'s plotting functions will cast the data to `numpy.ndarray`, so we need to \"dequantify\" first."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "missing-atmosphere",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "monthly_means.pint.dequantify(format=\"~P\").plot.imshow(col=\"month\", col_wrap=4)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/docs/examples/plotting.ipynb
+++ b/docs/examples/plotting.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "fabulous-watson",
+   "id": "round-optimization",
    "metadata": {},
    "source": [
     "# plotting quantified data"
@@ -11,7 +11,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "silver-coordinator",
+   "id": "greatest-smart",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -21,7 +21,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "dutch-wrestling",
+   "id": "fuzzy-maintenance",
    "metadata": {},
    "source": [
     "## load the data"
@@ -30,7 +30,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "reserved-genetics",
+   "id": "proved-racing",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -41,23 +41,20 @@
   },
   {
    "cell_type": "markdown",
-   "id": "moderate-comfort",
+   "id": "medium-backup",
    "metadata": {},
    "source": [
     "## convert units into a format understood by pint\n",
     "\n",
     "<div class=\"alert alert-info\">\n",
-    "    <strong>Note:</strong> this example uses the data provided by the <code>xarray.tutorial</code> functions.\n",
-    "    As such, the units attributes follow the CF conventions, which by default <code>pint</code> does not \n",
-    "    understand. To work around that, we are modifying the <code>units</code> attributes here, but in general it\n",
-    "    is better to use a library that modifies the <code>UnitRegistry</code>.\n",
+    "<strong>Note:</strong> this example uses the data provided by the <code>xarray.tutorial</code> functions. As such, the <code>units</code> attributes follow the CF conventions, which <code>pint</code> does not understand by default. To work around that, we are modifying the <code>units</code> attributes here, but in general it is better to use a library that adds support for the units used by the CF conventions to <code>pint</code>.\n",
     "</div>"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "passing-macintosh",
+   "id": "published-powell",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -67,7 +64,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "legal-arctic",
+   "id": "banned-tolerance",
    "metadata": {},
    "source": [
     "## quantify the data"
@@ -76,7 +73,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "advanced-seating",
+   "id": "divine-boost",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -86,7 +83,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "smoking-playback",
+   "id": "whole-momentum",
    "metadata": {},
    "source": [
     "## work with the data"
@@ -95,7 +92,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "satellite-performer",
+   "id": "dried-friday",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -110,7 +107,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "temporal-joint",
+   "id": "still-ebony",
    "metadata": {},
    "source": [
     "## plot\n",
@@ -121,7 +118,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "sensitive-television",
+   "id": "united-machine",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/docs/examples/plotting.ipynb
+++ b/docs/examples/plotting.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "ignored-brain",
+   "id": "short-alcohol",
    "metadata": {},
    "source": [
     "# plotting quantified data"
@@ -11,7 +11,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "sealed-bishop",
+   "id": "applied-caution",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -21,7 +21,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "binding-financing",
+   "id": "pressed-subscriber",
    "metadata": {},
    "source": [
     "## load the data"
@@ -30,7 +30,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "round-consistency",
+   "id": "amino-junction",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -41,13 +41,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "collective-surrey",
+   "id": "solved-inspector",
    "metadata": {},
    "source": [
     "## convert units into a format understood by pint\n",
     "\n",
     "<!-- Use one of the alert classes: alert-info, alert-warning, alert-success, alert-danger -->\n",
-    "<div class=\"alert alert-block alert-warning\">\n",
+    "<div class=\"alert alert-info\">\n",
     "    <b>Note:</b> this example uses the data provided by the <tt>xarray.tutorial</tt> functions. As such, the units attributes follow the CF conventions, which by default <tt>pint</tt> does not understand. To work around that, we're modifying the <tt>units</tt> attributes here, but in general it is better to use a library that modifies the <tt>UnitRegistry</tt>.\n",
     "</div>"
    ]
@@ -55,7 +55,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "satisfied-baseline",
+   "id": "nonprofit-routine",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -65,7 +65,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "indonesian-stuff",
+   "id": "impaired-giving",
    "metadata": {},
    "source": [
     "## quantify the data"
@@ -74,7 +74,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "affected-input",
+   "id": "amended-summary",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -84,7 +84,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "every-minnesota",
+   "id": "fatty-penguin",
    "metadata": {},
    "source": [
     "## work with the data"
@@ -93,7 +93,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "measured-encounter",
+   "id": "demonstrated-movement",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -108,7 +108,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "creative-member",
+   "id": "stone-excess",
    "metadata": {},
    "source": [
     "## plot\n",
@@ -119,7 +119,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "round-symphony",
+   "id": "accessory-monster",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/docs/examples/plotting.ipynb
+++ b/docs/examples/plotting.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "adjacent-acting",
+   "id": "fabulous-watson",
    "metadata": {},
    "source": [
     "# plotting quantified data"
@@ -11,7 +11,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "iraqi-maintenance",
+   "id": "silver-coordinator",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -21,7 +21,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "blessed-cancellation",
+   "id": "dutch-wrestling",
    "metadata": {},
    "source": [
     "## load the data"
@@ -30,7 +30,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "advance-portal",
+   "id": "reserved-genetics",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -41,7 +41,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "hired-tonight",
+   "id": "moderate-comfort",
    "metadata": {},
    "source": [
     "## convert units into a format understood by pint\n",
@@ -49,7 +49,7 @@
     "<div class=\"alert alert-info\">\n",
     "    <strong>Note:</strong> this example uses the data provided by the <code>xarray.tutorial</code> functions.\n",
     "    As such, the units attributes follow the CF conventions, which by default <code>pint</code> does not \n",
-    "    understand. To work around that, we're modifying the <code>units</code> attributes here, but in general it\n",
+    "    understand. To work around that, we are modifying the <code>units</code> attributes here, but in general it\n",
     "    is better to use a library that modifies the <code>UnitRegistry</code>.\n",
     "</div>"
    ]
@@ -57,7 +57,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "strong-inclusion",
+   "id": "passing-macintosh",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -67,7 +67,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "romantic-operation",
+   "id": "legal-arctic",
    "metadata": {},
    "source": [
     "## quantify the data"
@@ -76,7 +76,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "eligible-warner",
+   "id": "advanced-seating",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -86,7 +86,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "massive-international",
+   "id": "smoking-playback",
    "metadata": {},
    "source": [
     "## work with the data"
@@ -95,7 +95,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "productive-rhythm",
+   "id": "satellite-performer",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -110,7 +110,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "inside-blame",
+   "id": "temporal-joint",
    "metadata": {},
    "source": [
     "## plot\n",
@@ -121,7 +121,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "athletic-external",
+   "id": "sensitive-television",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/docs/examples/plotting.ipynb
+++ b/docs/examples/plotting.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "documentary-giant",
+   "id": "ignored-brain",
    "metadata": {},
    "source": [
     "# plotting quantified data"
@@ -11,7 +11,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "homeless-ballot",
+   "id": "sealed-bishop",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -21,7 +21,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "latter-repeat",
+   "id": "binding-financing",
    "metadata": {},
    "source": [
     "## load the data"
@@ -30,7 +30,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "comprehensive-senegal",
+   "id": "round-consistency",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -41,13 +41,13 @@
   },
   {
    "cell_type": "markdown",
-   "id": "precious-grocery",
+   "id": "collective-surrey",
    "metadata": {},
    "source": [
     "## convert units into a format understood by pint\n",
     "\n",
     "<!-- Use one of the alert classes: alert-info, alert-warning, alert-success, alert-danger -->\n",
-    "<div class=\"alert alert-block\">\n",
+    "<div class=\"alert alert-block alert-warning\">\n",
     "    <b>Note:</b> this example uses the data provided by the <tt>xarray.tutorial</tt> functions. As such, the units attributes follow the CF conventions, which by default <tt>pint</tt> does not understand. To work around that, we're modifying the <tt>units</tt> attributes here, but in general it is better to use a library that modifies the <tt>UnitRegistry</tt>.\n",
     "</div>"
    ]
@@ -55,7 +55,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "dress-vegetarian",
+   "id": "satisfied-baseline",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -65,7 +65,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "convinced-recorder",
+   "id": "indonesian-stuff",
    "metadata": {},
    "source": [
     "## quantify the data"
@@ -74,7 +74,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "mechanical-animal",
+   "id": "affected-input",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -84,7 +84,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "warming-lingerie",
+   "id": "every-minnesota",
    "metadata": {},
    "source": [
     "## work with the data"
@@ -93,7 +93,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "major-enclosure",
+   "id": "measured-encounter",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -108,7 +108,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "expired-chest",
+   "id": "creative-member",
    "metadata": {},
    "source": [
     "## plot\n",
@@ -119,7 +119,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "missing-atmosphere",
+   "id": "round-symphony",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/docs/examples/plotting.ipynb
+++ b/docs/examples/plotting.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "short-alcohol",
+   "id": "adjacent-acting",
    "metadata": {},
    "source": [
     "# plotting quantified data"
@@ -11,7 +11,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "applied-caution",
+   "id": "iraqi-maintenance",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -21,7 +21,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "pressed-subscriber",
+   "id": "blessed-cancellation",
    "metadata": {},
    "source": [
     "## load the data"
@@ -30,7 +30,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "amino-junction",
+   "id": "advance-portal",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -41,21 +41,23 @@
   },
   {
    "cell_type": "markdown",
-   "id": "solved-inspector",
+   "id": "hired-tonight",
    "metadata": {},
    "source": [
     "## convert units into a format understood by pint\n",
     "\n",
-    "<!-- Use one of the alert classes: alert-info, alert-warning, alert-success, alert-danger -->\n",
     "<div class=\"alert alert-info\">\n",
-    "    <b>Note:</b> this example uses the data provided by the <tt>xarray.tutorial</tt> functions. As such, the units attributes follow the CF conventions, which by default <tt>pint</tt> does not understand. To work around that, we're modifying the <tt>units</tt> attributes here, but in general it is better to use a library that modifies the <tt>UnitRegistry</tt>.\n",
+    "    <strong>Note:</strong> this example uses the data provided by the <code>xarray.tutorial</code> functions.\n",
+    "    As such, the units attributes follow the CF conventions, which by default <code>pint</code> does not \n",
+    "    understand. To work around that, we're modifying the <code>units</code> attributes here, but in general it\n",
+    "    is better to use a library that modifies the <code>UnitRegistry</code>.\n",
     "</div>"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "nonprofit-routine",
+   "id": "strong-inclusion",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -65,7 +67,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "impaired-giving",
+   "id": "romantic-operation",
    "metadata": {},
    "source": [
     "## quantify the data"
@@ -74,7 +76,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "amended-summary",
+   "id": "eligible-warner",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -84,7 +86,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fatty-penguin",
+   "id": "massive-international",
    "metadata": {},
    "source": [
     "## work with the data"
@@ -93,7 +95,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "demonstrated-movement",
+   "id": "productive-rhythm",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -108,7 +110,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "stone-excess",
+   "id": "inside-blame",
    "metadata": {},
    "source": [
     "## plot\n",
@@ -119,7 +121,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "accessory-monster",
+   "id": "athletic-external",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -5,4 +5,5 @@ sphinx>=3.2
 sphinx_rtd_theme
 ipython
 nbsphinx
+matplotlib-base
 sphinx-autosummary-accessors

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,6 +4,8 @@ netCDF4
 sphinx>=3.2
 sphinx_rtd_theme
 ipython
+ipykernel
+jupyter_client
 nbsphinx
 matplotlib
 sphinx-autosummary-accessors

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -5,5 +5,5 @@ sphinx>=3.2
 sphinx_rtd_theme
 ipython
 nbsphinx
-matplotlib-base
+matplotlib
 sphinx-autosummary-accessors

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -8,3 +8,6 @@ python:
     - requirements: docs/requirements.txt
     - method: pip
       path: .
+
+sphinx:
+  fail_on_warning: true


### PR DESCRIPTION
We are currently lacking examples. This adds a plotting example using `xarray`'s tutorial dataset (`air_temperature`), but since `pint-xarray` is domain agnostic, it would be cool to have examples from different domains.