### PR TITLE
fix broken links in the docs

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -2,6 +2,10 @@ API reference
 =============
 This page contains a auto-generated summary of ``pint-xarray``'s API.
 
+.. autosummary::
+   :toctree: generated/
+
+   pint_xarray.unit_registry
 
 Dataset
 -------

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -16,8 +16,6 @@ Dataset
    xarray.Dataset.pint.quantify
    xarray.Dataset.pint.dequantify
    xarray.Dataset.pint.to
-   xarray.Dataset.pint.to_base_units
-   xarray.Dataset.pint.to_system
 
 DataArray
 ---------
@@ -37,7 +35,6 @@ DataArray
    xarray.DataArray.pint.quantify
    xarray.DataArray.pint.dequantify
    xarray.DataArray.pint.to
-   xarray.DataArray.pint.to_base_units
 
 Testing
 -------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -106,4 +106,5 @@ intersphinx_mapping = {
     "python": ("https://docs.python.org/3/", None),
     "xarray": ("https://xarray.pydata.org/en/stable", None),
     "pint": ("https://pint.readthedocs.io/en/stable", None),
+    "pandas": ("https://pandas.pydata.org/pandas-docs/stable", None),
 }

--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -1,3 +1,5 @@
+.. currentmodule:: xarray
+
 What's new
 ==========
 


### PR DESCRIPTION
Not sure about the docstring of `pint_xarray.unit_registry`, though.