### PR TITLE
Convert all data variables in a Dataset to the same unit.

### DIFF
--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -13,6 +13,9 @@ What's new
   options on unit registries (:pull:`59`)
 - allow passing a format string to :py:meth:`Dataset.pint.dequantify` and
   :py:meth:`DataArray.pint.dequantify` (:pull:`49`)
+- allow converting all data variables in a Dataset to the same units using
+  :py:meth:`Dataset.pint.to` (:issue:`45`, :pull:`63`).
+  By `Mika Pflüger <https://github.com/mikapfl>`_.
 
 v0.1 (October 26 2020)
 ----------------------

--- a/pint_xarray/accessors.py
+++ b/pint_xarray/accessors.py
@@ -667,9 +667,10 @@ class PintDatasetAccessor:
             b        (x) float64 [g] -0.001 -0.00075 -0.0005 -0.00025 0.0
         """
         if isinstance(units, (str, pint.Unit)):
-            units = {x: units for x in self.ds.keys()}
-            units.update(unit_kwargs)
-            unit_kwargs = None
+            unit_kwargs.update(
+                {name: units for name in self.ds.keys() if name not in unit_kwargs}
+            )
+            units = None
         elif units is not None and not is_dict_like(units):
             raise ValueError(
                 "units must be either a string, a pint.Unit object or a dict-like,"

--- a/pint_xarray/tests/test_accessors.py
+++ b/pint_xarray/tests/test_accessors.py
@@ -7,7 +7,7 @@ from pint.errors import UndefinedUnitError
 from xarray.testing import assert_equal
 
 from .. import accessors, conversion
-from .utils import raises_regex
+from .utils import assert_units_equal, raises_regex
 
 pytestmark = [
     pytest.mark.filterwarnings("error::pint.UnitStrippedWarning"),

--- a/pint_xarray/tests/test_accessors.py
+++ b/pint_xarray/tests/test_accessors.py
@@ -297,5 +297,5 @@ def test_to_dataset(units_arg, units_kwargs):
     )
 
     actual = ds.pint.to(units_arg, **units_kwargs)
-    assert conversion.extract_units(actual) == conversion.extract_units(expected)
+    assert_units_equal(actual, expected)
     assert_equal(expected, actual)


### PR DESCRIPTION
Add the ability to convert all data variables in a Dataset to the same unit by giving a single unit-like instead of a dictionary.

Closes: #45 
