### PR TITLE
reindex and reindex_like

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -15,8 +15,10 @@ Dataset
 
    xarray.Dataset.pint.quantify
    xarray.Dataset.pint.dequantify
-   xarray.Dataset.pint.to
+   xarray.Dataset.pint.reindex
+   xarray.Dataset.pint.reindex_like
    xarray.Dataset.pint.sel
+   xarray.Dataset.pint.to
 
 DataArray
 ---------
@@ -35,8 +37,10 @@ DataArray
 
    xarray.DataArray.pint.quantify
    xarray.DataArray.pint.dequantify
-   xarray.DataArray.pint.to
+   xarray.DataArray.pint.reindex
+   xarray.DataArray.pint.reindex_like
    xarray.DataArray.pint.sel
+   xarray.DataArray.pint.to
 
 Testing
 -------

--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -25,6 +25,9 @@ What's new
   By `Mika Pflüger <https://github.com/mikapfl>`_.
 - implement :py:meth:`Dataset.pint.sel` and :py:meth:`DataArray.pint.sel` (:pull:`60`).
   By `Justus Magin <https://github.com/keewis>`_.
+- implement :py:meth:`Dataset.pint.reindex`, :py:meth:`Dataset.pint.reindex_like`,
+  :py:meth:`DataArray.pint.reindex` and :py:meth:`DataArray.pint.reindex_like` (:pull:`69`).
+  By `Justus Magin <https://github.com/keewis>`_.
 
 v0.1 (October 26 2020)
 ----------------------

--- a/pint_xarray/accessors.py
+++ b/pint_xarray/accessors.py
@@ -420,7 +420,21 @@ class PintDataArrayAccessor:
         fill_value=NA,
         **indexers_kwargs,
     ):
-        """unit-aware version of reindex"""
+        """unit-aware version of reindex
+
+        Just like :py:meth:`DataArray.reindex`, except the dataset's indexes are converted
+        to the units of the indexers first.
+
+        .. note::
+            ``tolerance`` and ``fill_value`` are not supported, yet. They will be passed through to
+            ``DataArray.reindex`` unmodified.
+
+        See Also
+        --------
+        xarray.Dataset.pint.reindex
+        xarray.DataArray.pint.reindex_like
+        xarray.DataArray.reindex
+        """
         indexers = either_dict_or_kwargs(indexers, indexers_kwargs, "reindex")
 
         indexer_units = {
@@ -474,7 +488,21 @@ class PintDataArrayAccessor:
     def reindex_like(
         self, other, method=None, tolerance=None, copy=True, fill_value=NA
     ):
-        """unit-aware version of reindex_like"""
+        """unit-aware version of reindex_like
+
+        Just like :py:meth:`DataArray.reindex_like`, except the dataset's indexes are converted
+        to the units of the indexers first.
+
+        .. note::
+            ``tolerance`` and ``fill_value`` are not supported, yet. They will be passed through to
+            ``DataArray.reindex_like`` unmodified.
+
+        See Also
+        --------
+        xarray.Dataset.pint.reindex_like
+        xarray.DataArray.pint.reindex
+        xarray.DataArray.reindex_like
+        """
         indexer_units = conversion.extract_unit_attributes(other)
 
         # TODO: handle tolerance
@@ -861,7 +889,21 @@ class PintDatasetAccessor:
         fill_value=NA,
         **indexers_kwargs,
     ):
-        """unit-aware version of reindex"""
+        """unit-aware version of reindex
+
+        Just like :py:meth:`Dataset.reindex`, except the dataset's indexes are converted
+        to the units of the indexers first.
+
+        .. note::
+            ``tolerance`` and ``fill_value`` are not supported, yet. They will be passed through to
+            ``Dataset.reindex`` unmodified.
+
+        See Also
+        --------
+        xarray.DataArray.pint.reindex
+        xarray.Dataset.pint.reindex_like
+        xarray.Dataset.reindex
+        """
         indexers = either_dict_or_kwargs(indexers, indexers_kwargs, "reindex")
 
         indexer_units = {
@@ -915,7 +957,21 @@ class PintDatasetAccessor:
     def reindex_like(
         self, other, method=None, tolerance=None, copy=True, fill_value=NA
     ):
-        """unit-aware version of reindex_like"""
+        """unit-aware version of reindex_like
+
+        Just like :py:meth:`Dataset.reindex_like`, except the dataset's indexes are converted
+        to the units of the indexers first.
+
+        .. note::
+            ``tolerance`` and ``fill_value`` are not supported, yet. They will be passed through to
+            ``Dataset.reindex_like`` unmodified.
+
+        See Also
+        --------
+        xarray.DataArray.pint.reindex_like
+        xarray.Dataset.pint.reindex
+        xarray.Dataset.reindex_like
+        """
         indexer_units = conversion.extract_unit_attributes(other)
 
         # TODO: handle tolerance

--- a/pint_xarray/accessors.py
+++ b/pint_xarray/accessors.py
@@ -5,6 +5,7 @@ import pint
 from pint.quantity import Quantity
 from pint.unit import Unit
 from xarray import register_dataarray_accessor, register_dataset_accessor
+from xarray.core.dtypes import NA
 
 from . import conversion
 from .errors import DimensionalityError
@@ -749,6 +750,66 @@ class PintDatasetAccessor:
         units = either_dict_or_kwargs(units, unit_kwargs, "to")
 
         return conversion.convert_units(self.ds, units)
+
+    def reindex(
+        self,
+        indexers=None,
+        method=None,
+        tolerance=None,
+        copy=True,
+        fill_value=NA,
+        **indexers_kwargs,
+    ):
+        """unit-aware version of reindex"""
+        indexers = either_dict_or_kwargs(indexers, indexers_kwargs, "reindex")
+
+        indexer_units = {
+            name: conversion.extract_indexer_units(indexer)
+            for name, indexer in indexers.items()
+        }
+
+        # TODO: handle tolerance
+        # TODO: handle fill_value
+
+        # make sure we only have compatible units
+        dims = self.ds.dims
+        unit_attrs = conversion.extract_unit_attributes(self.ds)
+        index_units = {
+            name: units for name, units in unit_attrs.items() if name in dims
+        }
+
+        registry = get_registry(None, index_units, indexer_units)
+
+        units = zip_mappings(indexer_units, index_units)
+        incompatible_units = [
+            key
+            for key, (indexer_unit, index_unit) in units.items()
+            if (
+                None not in (indexer_unit, index_unit)
+                and not registry.is_compatible_with(indexer_unit, index_unit)
+            )
+        ]
+        if incompatible_units:
+            units1 = {key: indexer_units[key] for key in incompatible_units}
+            units2 = {key: index_units[key] for key in incompatible_units}
+            raise DimensionalityError(units1, units2)
+
+        # convert the indexes to the indexer's units
+        converted = conversion.convert_units(self.ds, indexer_units)
+
+        # index
+        stripped_indexers = {
+            name: conversion.strip_indexer_units(indexer)
+            for name, indexer in indexers.items()
+        }
+        indexed = converted.reindex(
+            stripped_indexers,
+            method=method,
+            tolerance=tolerance,
+            copy=copy,
+            fill_value=fill_value,
+        )
+        return indexed
 
     def sel(
         self, indexers=None, method=None, tolerance=None, drop=False, **indexers_kwargs

--- a/pint_xarray/accessors.py
+++ b/pint_xarray/accessors.py
@@ -422,7 +422,7 @@ class PintDataArrayAccessor:
     ):
         """unit-aware version of reindex
 
-        Just like :py:meth:`DataArray.reindex`, except the dataset's indexes are converted
+        Just like :py:meth:`xarray.DataArray.reindex`, except the dataset's indexes are converted
         to the units of the indexers first.
 
         .. note::
@@ -490,7 +490,7 @@ class PintDataArrayAccessor:
     ):
         """unit-aware version of reindex_like
 
-        Just like :py:meth:`DataArray.reindex_like`, except the dataset's indexes are converted
+        Just like :py:meth:`xarray.DataArray.reindex_like`, except the dataset's indexes are converted
         to the units of the indexers first.
 
         .. note::
@@ -545,7 +545,7 @@ class PintDataArrayAccessor:
     ):
         """unit-aware version of sel
 
-        Just like :py:meth:`DataArray.sel`, except the dataset's indexes are converted
+        Just like :py:meth:`xarray.DataArray.sel`, except the dataset's indexes are converted
         to the units of the indexers first.
 
         .. note::
@@ -891,7 +891,7 @@ class PintDatasetAccessor:
     ):
         """unit-aware version of reindex
 
-        Just like :py:meth:`Dataset.reindex`, except the dataset's indexes are converted
+        Just like :py:meth:`xarray.Dataset.reindex`, except the dataset's indexes are converted
         to the units of the indexers first.
 
         .. note::
@@ -959,7 +959,7 @@ class PintDatasetAccessor:
     ):
         """unit-aware version of reindex_like
 
-        Just like :py:meth:`Dataset.reindex_like`, except the dataset's indexes are converted
+        Just like :py:meth:`xarray.Dataset.reindex_like`, except the dataset's indexes are converted
         to the units of the indexers first.
 
         .. note::

--- a/pint_xarray/accessors.py
+++ b/pint_xarray/accessors.py
@@ -811,6 +811,21 @@ class PintDatasetAccessor:
         )
         return indexed
 
+    def reindex_like(
+        self, other, method=None, tolerance=None, copy=True, fill_value=NA
+    ):
+        """unit-aware version of reindex_like"""
+        from xarray.core import alignment
+
+        indexers = alignment.reindex_like_indexers(self, other)
+        return self.reindex(
+            indexers=indexers,
+            method=method,
+            tolerance=tolerance,
+            copy=copy,
+            fill_value=fill_value,
+        )
+
     def sel(
         self, indexers=None, method=None, tolerance=None, drop=False, **indexers_kwargs
     ):

--- a/pint_xarray/tests/test_accessors.py
+++ b/pint_xarray/tests/test_accessors.py
@@ -499,7 +499,7 @@ def test_sel(obj, indexers, expected, error):
             ),
             {"x": Quantity([1, 3, 5], "m"), "y": Quantity([0, 2], "min")},
             xr.DataArray(
-                [[np.nan, np.nan], [np.nan, np.nan], [np.nan, np.nan]],
+                [[np.nan, 1], [np.nan, 5], [np.nan, np.nan]],
                 dims=("x", "y"),
                 coords={
                     "x": ("x", [1, 3, 5], {"units": unit_registry.Unit("m")}),

--- a/pint_xarray/tests/test_accessors.py
+++ b/pint_xarray/tests/test_accessors.py
@@ -536,7 +536,7 @@ def test_reindex(obj, indexers, expected, error):
 
 
 @pytest.mark.parametrize(
-    ["obj", "indexers", "expected", "error"],
+    ["obj", "other", "expected", "error"],
     (
         pytest.param(
             xr.Dataset(
@@ -546,7 +546,10 @@ def test_reindex(obj, indexers, expected, error):
                 }
             ),
             xr.Dataset(
-                {"x": Quantity([10, 30, 50], "dm"), "y": Quantity([0, 120, 240], "s")}
+                {
+                    "x": ("x", [10, 30, 50], {"units": unit_registry.Unit("dm")}),
+                    "y": ("y", [0, 120, 240], {"units": unit_registry.Unit("s")}),
+                }
             ),
             xr.Dataset(
                 {
@@ -565,7 +568,10 @@ def test_reindex(obj, indexers, expected, error):
                 }
             ),
             xr.Dataset(
-                {"x": Quantity([0, 1, 3, 5], "m"), "y": Quantity([0, 2, 4], "min")}
+                {
+                    "x": ("x", [0, 1, 3, 5], {"units": unit_registry.Unit("m")}),
+                    "y": ("y", [0, 2, 4], {"units": unit_registry.Unit("min")}),
+                }
             ),
             xr.Dataset(
                 {
@@ -583,7 +589,12 @@ def test_reindex(obj, indexers, expected, error):
                     "y": ("y", [60, 120], {"units": unit_registry.Unit("s")}),
                 }
             ),
-            xr.Dataset({"x": Quantity([1, 3], "s"), "y": Quantity([1], "m")}),
+            xr.Dataset(
+                {
+                    "x": ("x", [1, 3], {"units": unit_registry.Unit("s")}),
+                    "y": ("y", [1], {"units": unit_registry.Unit("m")}),
+                }
+            ),
             None,
             DimensionalityError,
             id="Dataset-incompatible units",
@@ -598,7 +609,10 @@ def test_reindex(obj, indexers, expected, error):
                 },
             ),
             xr.Dataset(
-                {"x": Quantity([10, 30, 50], "dm"), "y": Quantity([0, 240], "s")}
+                {
+                    "x": ("x", [10, 30, 50], {"units": unit_registry.Unit("dm")}),
+                    "y": ("y", [0, 240], {"units": unit_registry.Unit("s")}),
+                }
             ),
             xr.DataArray(
                 [[np.nan, np.nan], [np.nan, np.nan], [np.nan, np.nan]],
@@ -620,7 +634,12 @@ def test_reindex(obj, indexers, expected, error):
                     "y": ("y", [60, 120], {"units": unit_registry.Unit("s")}),
                 },
             ),
-            xr.Dataset({"x": Quantity([1, 3, 5], "m"), "y": Quantity([0, 2], "min")}),
+            xr.Dataset(
+                {
+                    "x": ("x", [1, 3, 5], {"units": unit_registry.Unit("m")}),
+                    "y": ("y", [0, 2], {"units": unit_registry.Unit("min")}),
+                }
+            ),
             xr.DataArray(
                 [[np.nan, 1], [np.nan, 5], [np.nan, np.nan]],
                 dims=("x", "y"),
@@ -641,7 +660,12 @@ def test_reindex(obj, indexers, expected, error):
                     "y": ("y", [60, 120], {"units": unit_registry.Unit("s")}),
                 },
             ),
-            xr.Dataset({"x": Quantity([10, 30], "s"), "y": Quantity([60], "m")}),
+            xr.Dataset(
+                {
+                    "x": ("x", [10, 30], {"units": unit_registry.Unit("s")}),
+                    "y": ("y", [60], {"units": unit_registry.Unit("m")}),
+                }
+            ),
             None,
             DimensionalityError,
             id="DataArray-incompatible units",

--- a/pint_xarray/tests/test_accessors.py
+++ b/pint_xarray/tests/test_accessors.py
@@ -533,3 +533,126 @@ def test_reindex(obj, indexers, expected, error):
         actual = obj.pint.reindex(indexers)
         assert_units_equal(actual, expected)
         assert_identical(actual, expected)
+
+
+@pytest.mark.parametrize(
+    ["obj", "indexers", "expected", "error"],
+    (
+        pytest.param(
+            xr.Dataset(
+                {
+                    "x": ("x", [10, 20, 30], {"units": unit_registry.Unit("dm")}),
+                    "y": ("y", [60, 120], {"units": unit_registry.Unit("s")}),
+                }
+            ),
+            xr.Dataset(
+                {"x": Quantity([10, 30, 50], "dm"), "y": Quantity([0, 120, 240], "s")}
+            ),
+            xr.Dataset(
+                {
+                    "x": ("x", [10, 30, 50], {"units": unit_registry.Unit("dm")}),
+                    "y": ("y", [0, 120, 240], {"units": unit_registry.Unit("s")}),
+                }
+            ),
+            None,
+            id="Dataset-identical units",
+        ),
+        pytest.param(
+            xr.Dataset(
+                {
+                    "x": ("x", [10, 20, 30], {"units": unit_registry.Unit("dm")}),
+                    "y": ("y", [60, 120], {"units": unit_registry.Unit("s")}),
+                }
+            ),
+            xr.Dataset(
+                {"x": Quantity([0, 1, 3, 5], "m"), "y": Quantity([0, 2, 4], "min")}
+            ),
+            xr.Dataset(
+                {
+                    "x": ("x", [0, 1, 3, 5], {"units": unit_registry.Unit("m")}),
+                    "y": ("y", [0, 2, 4], {"units": unit_registry.Unit("min")}),
+                }
+            ),
+            None,
+            id="Dataset-compatible units",
+        ),
+        pytest.param(
+            xr.Dataset(
+                {
+                    "x": ("x", [10, 20, 30], {"units": unit_registry.Unit("dm")}),
+                    "y": ("y", [60, 120], {"units": unit_registry.Unit("s")}),
+                }
+            ),
+            xr.Dataset({"x": Quantity([1, 3], "s"), "y": Quantity([1], "m")}),
+            None,
+            DimensionalityError,
+            id="Dataset-incompatible units",
+        ),
+        pytest.param(
+            xr.DataArray(
+                [[0, 1], [2, 3], [4, 5]],
+                dims=("x", "y"),
+                coords={
+                    "x": ("x", [10, 20, 30], {"units": unit_registry.Unit("dm")}),
+                    "y": ("y", [60, 120], {"units": unit_registry.Unit("s")}),
+                },
+            ),
+            xr.Dataset(
+                {"x": Quantity([10, 30, 50], "dm"), "y": Quantity([0, 240], "s")}
+            ),
+            xr.DataArray(
+                [[np.nan, np.nan], [np.nan, np.nan], [np.nan, np.nan]],
+                dims=("x", "y"),
+                coords={
+                    "x": ("x", [10, 30, 50], {"units": unit_registry.Unit("dm")}),
+                    "y": ("y", [0, 240], {"units": unit_registry.Unit("s")}),
+                },
+            ),
+            None,
+            id="DataArray-identical units",
+        ),
+        pytest.param(
+            xr.DataArray(
+                [[0, 1], [2, 3], [4, 5]],
+                dims=("x", "y"),
+                coords={
+                    "x": ("x", [10, 20, 30], {"units": unit_registry.Unit("dm")}),
+                    "y": ("y", [60, 120], {"units": unit_registry.Unit("s")}),
+                },
+            ),
+            xr.Dataset({"x": Quantity([1, 3, 5], "m"), "y": Quantity([0, 2], "min")}),
+            xr.DataArray(
+                [[np.nan, 1], [np.nan, 5], [np.nan, np.nan]],
+                dims=("x", "y"),
+                coords={
+                    "x": ("x", [1, 3, 5], {"units": unit_registry.Unit("m")}),
+                    "y": ("y", [0, 2], {"units": unit_registry.Unit("min")}),
+                },
+            ),
+            None,
+            id="DataArray-compatible units",
+        ),
+        pytest.param(
+            xr.DataArray(
+                [[0, 1], [2, 3], [4, 5]],
+                dims=("x", "y"),
+                coords={
+                    "x": ("x", [10, 20, 30], {"units": unit_registry.Unit("dm")}),
+                    "y": ("y", [60, 120], {"units": unit_registry.Unit("s")}),
+                },
+            ),
+            xr.Dataset({"x": Quantity([10, 30], "s"), "y": Quantity([60], "m")}),
+            None,
+            DimensionalityError,
+            id="DataArray-incompatible units",
+        ),
+    ),
+)
+def test_reindex_like(obj, other, expected, error):
+    if error is not None:
+        with pytest.raises(error):
+            obj.pint.reindex_like(other)
+    else:
+        actual = obj.pint.reindex_like(other)
+        assert_units_equal(actual, expected)
+        assert_identical(actual, expected)

--- a/pint_xarray/tests/test_accessors.py
+++ b/pint_xarray/tests/test_accessors.py
@@ -416,3 +416,120 @@ def test_sel(obj, indexers, expected, error):
         actual = obj.pint.sel(indexers)
         assert_units_equal(actual, expected)
         assert_identical(actual, expected)
+
+
+@pytest.mark.parametrize(
+    ["obj", "indexers", "expected", "error"],
+    (
+        pytest.param(
+            xr.Dataset(
+                {
+                    "x": ("x", [10, 20, 30], {"units": unit_registry.Unit("dm")}),
+                    "y": ("y", [60, 120], {"units": unit_registry.Unit("s")}),
+                }
+            ),
+            {"x": Quantity([10, 30, 50], "dm"), "y": Quantity([0, 120, 240], "s")},
+            xr.Dataset(
+                {
+                    "x": ("x", [10, 30, 50], {"units": unit_registry.Unit("dm")}),
+                    "y": ("y", [0, 120, 240], {"units": unit_registry.Unit("s")}),
+                }
+            ),
+            None,
+            id="Dataset-identical units",
+        ),
+        pytest.param(
+            xr.Dataset(
+                {
+                    "x": ("x", [10, 20, 30], {"units": unit_registry.Unit("dm")}),
+                    "y": ("y", [60, 120], {"units": unit_registry.Unit("s")}),
+                }
+            ),
+            {"x": Quantity([0, 1, 3, 5], "m"), "y": Quantity([0, 2, 4], "min")},
+            xr.Dataset(
+                {
+                    "x": ("x", [0, 1, 3, 5], {"units": unit_registry.Unit("m")}),
+                    "y": ("y", [0, 2, 4], {"units": unit_registry.Unit("min")}),
+                }
+            ),
+            None,
+            id="Dataset-compatible units",
+        ),
+        pytest.param(
+            xr.Dataset(
+                {
+                    "x": ("x", [10, 20, 30], {"units": unit_registry.Unit("dm")}),
+                    "y": ("y", [60, 120], {"units": unit_registry.Unit("s")}),
+                }
+            ),
+            {"x": Quantity([1, 3], "s"), "y": Quantity([1], "m")},
+            None,
+            DimensionalityError,
+            id="Dataset-incompatible units",
+        ),
+        pytest.param(
+            xr.DataArray(
+                [[0, 1], [2, 3], [4, 5]],
+                dims=("x", "y"),
+                coords={
+                    "x": ("x", [10, 20, 30], {"units": unit_registry.Unit("dm")}),
+                    "y": ("y", [60, 120], {"units": unit_registry.Unit("s")}),
+                },
+            ),
+            {"x": Quantity([10, 30, 50], "dm"), "y": Quantity([0, 240], "s")},
+            xr.DataArray(
+                [[np.nan, np.nan], [np.nan, np.nan], [np.nan, np.nan]],
+                dims=("x", "y"),
+                coords={
+                    "x": ("x", [10, 30, 50], {"units": unit_registry.Unit("dm")}),
+                    "y": ("y", [0, 240], {"units": unit_registry.Unit("s")}),
+                },
+            ),
+            None,
+            id="DataArray-identical units",
+        ),
+        pytest.param(
+            xr.DataArray(
+                [[0, 1], [2, 3], [4, 5]],
+                dims=("x", "y"),
+                coords={
+                    "x": ("x", [10, 20, 30], {"units": unit_registry.Unit("dm")}),
+                    "y": ("y", [60, 120], {"units": unit_registry.Unit("s")}),
+                },
+            ),
+            {"x": Quantity([1, 3, 5], "m"), "y": Quantity([0, 2], "min")},
+            xr.DataArray(
+                [[np.nan, np.nan], [np.nan, np.nan], [np.nan, np.nan]],
+                dims=("x", "y"),
+                coords={
+                    "x": ("x", [1, 3, 5], {"units": unit_registry.Unit("m")}),
+                    "y": ("y", [0, 2], {"units": unit_registry.Unit("min")}),
+                },
+            ),
+            None,
+            id="DataArray-compatible units",
+        ),
+        pytest.param(
+            xr.DataArray(
+                [[0, 1], [2, 3], [4, 5]],
+                dims=("x", "y"),
+                coords={
+                    "x": ("x", [10, 20, 30], {"units": unit_registry.Unit("dm")}),
+                    "y": ("y", [60, 120], {"units": unit_registry.Unit("s")}),
+                },
+            ),
+            {"x": Quantity([10, 30], "s"), "y": Quantity([60], "m")},
+            None,
+            DimensionalityError,
+            id="DataArray-incompatible units",
+        ),
+    ),
+)
+def test_reindex(obj, indexers, expected, error):
+    if error is not None:
+        with pytest.raises(error):
+            obj.pint.reindex(indexers)
+    else:
+        actual = obj.pint.reindex(indexers)
+        assert_units_equal(actual, expected)
+        assert_identical(actual, expected)


### PR DESCRIPTION
Just like #60, this adds a unit-aware version of `reindex` and `reindex_like`.

- [x] passes `pre-commit run --all-files`