### PR TITLE
keep data units in interp / interp_like

### DIFF
--- a/ci/requirements.txt
+++ b/ci/requirements.txt
@@ -7,4 +7,3 @@ black
 flake8
 pytest
 pytest-cov
-pytest-azurepipelines

--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -29,7 +29,7 @@ What's new
   :py:meth:`DataArray.pint.reindex` and :py:meth:`DataArray.pint.reindex_like` (:pull:`69`).
   By `Justus Magin <https://github.com/keewis>`_.
 - implement :py:meth:`Dataset.pint.interp`, :py:meth:`Dataset.pint.interp_like`,
-  :py:meth:`DataArray.pint.interp` and :py:meth:`DataArray.pint.interp_like` (:pull:`72`).
+  :py:meth:`DataArray.pint.interp` and :py:meth:`DataArray.pint.interp_like` (:pull:`72`, :pull:`76`).
   By `Justus Magin <https://github.com/keewis>`_.
 
 v0.1 (October 26 2020)

--- a/pint_xarray/accessors.py
+++ b/pint_xarray/accessors.py
@@ -595,6 +595,7 @@ class PintDataArrayAccessor:
 
         # convert the indexes to the indexer's units
         converted = conversion.convert_units(self.da, indexer_units)
+        units = conversion.extract_units(converted)
         stripped = conversion.strip_units(converted)
 
         # index
@@ -608,7 +609,7 @@ class PintDataArrayAccessor:
             assume_sorted=False,
             kwargs=None,
         )
-        return conversion.attach_units(interpolated, indexer_units)
+        return conversion.attach_units(interpolated, units)
 
     def interp_like(self, other, method="linear", assume_sorted=False, kwargs=None):
         """unit-aware version of interp_like
@@ -652,6 +653,7 @@ class PintDataArrayAccessor:
             raise DimensionalityError(units1, units2)
 
         converted = conversion.convert_units(self.da, indexer_units)
+        units = conversion.extract_units(converted)
         stripped = conversion.strip_units(converted)
         interpolated = stripped.interp_like(
             other,
@@ -659,7 +661,7 @@ class PintDataArrayAccessor:
             assume_sorted=assume_sorted,
             kwargs=kwargs,
         )
-        return conversion.attach_units(interpolated, indexer_units)
+        return conversion.attach_units(interpolated, units)
 
     def sel(
         self, indexers=None, method=None, tolerance=None, drop=False, **indexers_kwargs
@@ -1185,6 +1187,7 @@ class PintDatasetAccessor:
 
         # convert the indexes to the indexer's units
         converted = conversion.convert_units(self.ds, indexer_units)
+        units = conversion.extract_units(converted)
         stripped = conversion.strip_units(converted)
 
         # index
@@ -1198,7 +1201,7 @@ class PintDatasetAccessor:
             assume_sorted=False,
             kwargs=None,
         )
-        return conversion.attach_units(interpolated, indexer_units)
+        return conversion.attach_units(interpolated, units)
 
     def interp_like(self, other, method="linear", assume_sorted=False, kwargs=None):
         """unit-aware version of interp_like
@@ -1242,6 +1245,7 @@ class PintDatasetAccessor:
             raise DimensionalityError(units1, units2)
 
         converted = conversion.convert_units(self.ds, indexer_units)
+        units = conversion.extract_units(converted)
         stripped = conversion.strip_units(converted)
         interpolated = stripped.interp_like(
             other,
@@ -1249,7 +1253,7 @@ class PintDatasetAccessor:
             assume_sorted=assume_sorted,
             kwargs=kwargs,
         )
-        return conversion.attach_units(interpolated, indexer_units)
+        return conversion.attach_units(interpolated, units)
 
     def sel(
         self, indexers=None, method=None, tolerance=None, drop=False, **indexers_kwargs

--- a/pint_xarray/conversion.py
+++ b/pint_xarray/conversion.py
@@ -93,7 +93,8 @@ def array_strip_units(data):
 def attach_units_variable(variable, units):
     if isinstance(variable, IndexVariable):
         new_obj = variable.copy()
-        new_obj.attrs[unit_attribute_name] = units
+        if units is not None:
+            new_obj.attrs[unit_attribute_name] = units
     elif isinstance(variable, Variable):
         new_data = array_attach_units(variable.data, units)
         new_obj = variable.copy(data=new_data)

--- a/pint_xarray/tests/test_accessors.py
+++ b/pint_xarray/tests/test_accessors.py
@@ -732,6 +732,28 @@ def test_reindex_like(obj, other, expected, error):
             id="Dataset-incompatible units",
         ),
         pytest.param(
+            xr.Dataset(
+                {
+                    "a": (("x", "y"), Quantity([[0, 1], [2, 3], [4, 5]], "kg")),
+                    "x": [10, 20, 30],
+                    "y": [60, 120],
+                }
+            ),
+            {
+                "x": [15, 25],
+                "y": [75, 105],
+            },
+            xr.Dataset(
+                {
+                    "a": (("x", "y"), Quantity([[1.25, 1.75], [3.25, 3.75]], "kg")),
+                    "x": [15, 25],
+                    "y": [75, 105],
+                }
+            ),
+            None,
+            id="Dataset-data units",
+        ),
+        pytest.param(
             xr.DataArray(
                 [[0, 1], [2, 3], [4, 5]],
                 dims=("x", "y"),
@@ -786,6 +808,30 @@ def test_reindex_like(obj, other, expected, error):
             None,
             DimensionalityError,
             id="DataArray-incompatible units",
+        ),
+        pytest.param(
+            xr.DataArray(
+                Quantity([[0, 1], [2, 3], [4, 5]], "kg"),
+                dims=("x", "y"),
+                coords={
+                    "x": [10, 20, 30],
+                    "y": [60, 120],
+                },
+            ),
+            {
+                "x": [15, 25],
+                "y": [75, 105],
+            },
+            xr.DataArray(
+                Quantity([[1.25, 1.75], [3.25, 3.75]], "kg"),
+                dims=("x", "y"),
+                coords={
+                    "x": [15, 25],
+                    "y": [75, 105],
+                },
+            ),
+            None,
+            id="DataArray-data units",
         ),
     ),
 )
@@ -890,6 +936,30 @@ def test_interp(obj, indexers, expected, error):
             id="DataArray-identical units",
         ),
         pytest.param(
+            xr.Dataset(
+                {
+                    "a": (("x", "y"), Quantity([[0, 1], [2, 3], [4, 5]], "kg")),
+                    "x": [10, 20, 30],
+                    "y": [60, 120],
+                }
+            ),
+            xr.Dataset(
+                {
+                    "x": [15, 25],
+                    "y": [75, 105],
+                }
+            ),
+            xr.Dataset(
+                {
+                    "a": (("x", "y"), Quantity([[1.25, 1.75], [3.25, 3.75]], "kg")),
+                    "x": [15, 25],
+                    "y": [75, 105],
+                }
+            ),
+            None,
+            id="Dataset-data units",
+        ),
+        pytest.param(
             xr.DataArray(
                 [[0, 1], [2, 3], [4, 5]],
                 dims=("x", "y"),
@@ -933,6 +1003,32 @@ def test_interp(obj, indexers, expected, error):
             None,
             DimensionalityError,
             id="DataArray-incompatible units",
+        ),
+        pytest.param(
+            xr.DataArray(
+                Quantity([[0, 1], [2, 3], [4, 5]], "kg"),
+                dims=("x", "y"),
+                coords={
+                    "x": [10, 20, 30],
+                    "y": [60, 120],
+                },
+            ),
+            xr.Dataset(
+                {
+                    "x": [15, 25],
+                    "y": [75, 105],
+                }
+            ),
+            xr.DataArray(
+                Quantity([[1.25, 1.75], [3.25, 3.75]], "kg"),
+                dims=("x", "y"),
+                coords={
+                    "x": [15, 25],
+                    "y": [75, 105],
+                },
+            ),
+            None,
+            id="DataArray-data units",
         ),
     ),
 )

--- a/pint_xarray/tests/test_conversion.py
+++ b/pint_xarray/tests/test_conversion.py
@@ -226,11 +226,16 @@ class TestXarrayFunctions:
         q_b = to_quantity(b, units.get("b"))
         q_u = to_quantity(u, units.get("u"))
 
+        units_x = units.get("x")
+
         obj = Dataset({"a": ("x", a), "b": ("x", b)}, coords={"u": ("x", u), "x": x})
         expected = Dataset(
             {"a": ("x", q_a), "b": ("x", q_b)},
-            coords={"u": ("x", q_u), "x": ("x", x, {"units": units.get("x")})},
+            coords={"u": ("x", q_u), "x": x},
         )
+        if units_x is not None:
+            expected.x.attrs["units"] = units_x
+
         if type == "DataArray":
             obj = obj["a"]
             expected = expected["a"]


### PR DESCRIPTION
`interp` and `interp_like` didn't preserve the units of the data.

- [x] Tests added
- [x] Passes `pre-commit run --all-files`
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
