### PR TITLE
interpolate_na

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -30,6 +30,7 @@ Dataset
    xarray.Dataset.pint.to
    xarray.Dataset.pint.ffill
    xarray.Dataset.pint.bfill
+   xarray.Dataset.pint.interpolate_na
 
 DataArray
 ---------
@@ -59,6 +60,7 @@ DataArray
    xarray.DataArray.pint.to
    xarray.DataArray.pint.ffill
    xarray.DataArray.pint.bfill
+   xarray.DataArray.pint.interpolate_na
 
 Testing
 -------

--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -38,6 +38,8 @@ What's new
 - implement :py:meth:`Dataset.pint.ffill`, :py:meth:`Dataset.pint.bfill`,
   :py:meth:`DataArray.pint.ffill` and :py:meth:`DataArray.pint.bfill` (:pull:`78`).
   By `Justus Magin <https://github.com/keewis>`_.
+- implement :py:meth:`Dataset.pint.interpolate_na` and :py:meth:`DataArray.pint.interpolate_na` (:pull:`82`).
+  By `Justus Magin <https://github.com/keewis>`_.
 
 v0.1 (October 26 2020)
 ----------------------

--- a/pint_xarray/accessors.py
+++ b/pint_xarray/accessors.py
@@ -998,6 +998,44 @@ class PintDataArrayAccessor:
 
         return conversion.attach_units(filled, units)
 
+    def interpolate_na(
+        self,
+        dim=None,
+        method="linear",
+        limit=None,
+        use_coordinate=True,
+        max_gap=None,
+        keep_attrs=None,
+        **kwargs,
+    ):
+        """unit-aware version of interpolate_na
+
+        Like :py:meth:`DataArray.interpolate_na` but without stripping the units on data or coordinates.
+
+        .. note::
+            ``max_gap`` is not supported, yet, and will be passed through to
+            ``DataArray.interpolate_na`` unmodified.
+
+        See Also
+        --------
+        xarray.Dataset.pint.interpolate_na
+        xarray.DataArray.interpolate_na
+        """
+        units = conversion.extract_units(self.da)
+        stripped = conversion.strip_units(self.da)
+
+        interpolated = stripped.interpolate_na(
+            dim=dim,
+            method=method,
+            limit=limit,
+            use_coordinate=use_coordinate,
+            max_gap=max_gap,
+            keep_attrs=keep_attrs,
+            **kwargs,
+        )
+
+        return conversion.attach_units(interpolated, units)
+
 
 @register_dataset_accessor("pint")
 class PintDatasetAccessor:
@@ -1697,3 +1735,41 @@ class PintDatasetAccessor:
         filled = stripped.bfill(dim=dim, limit=limit)
 
         return conversion.attach_units(filled, units)
+
+    def interpolate_na(
+        self,
+        dim=None,
+        method="linear",
+        limit=None,
+        use_coordinate=True,
+        max_gap=None,
+        keep_attrs=None,
+        **kwargs,
+    ):
+        """unit-aware version of interpolate_na
+
+        Like :py:meth:`Dataset.interpolate_na` but without stripping the units on data or coordinates.
+
+        .. note::
+            ``max_gap`` is not supported, yet, and will be passed through to
+            ``Dataset.interpolate_na`` unmodified.
+
+        See Also
+        --------
+        xarray.DataArray.pint.interpolate_na
+        xarray.Dataset.interpolate_na
+        """
+        units = conversion.extract_units(self.ds)
+        stripped = conversion.strip_units(self.ds)
+
+        interpolated = stripped.interpolate_na(
+            dim=dim,
+            method=method,
+            limit=limit,
+            use_coordinate=use_coordinate,
+            max_gap=max_gap,
+            keep_attrs=keep_attrs,
+            **kwargs,
+        )
+
+        return conversion.attach_units(interpolated, units)

--- a/pint_xarray/tests/test_accessors.py
+++ b/pint_xarray/tests/test_accessors.py
@@ -1624,3 +1624,97 @@ def test_bfill(obj, expected):
     actual = obj.pint.bfill(dim="x")
     assert_identical(actual, expected)
     assert_units_equal(actual, expected)
+
+
+@pytest.mark.parametrize(
+    ["obj", "expected"],
+    (
+        pytest.param(
+            xr.Dataset(
+                {"a": ("x", [nan, 0, nan, 1, nan, nan, nan, 2, nan])},
+                coords={"u": ("x", [nan, 0, nan, 1, nan, nan, nan, 2, nan])},
+            ),
+            xr.Dataset(
+                {"a": ("x", [nan, 0, 0.5, 1, 1.25, 1.5, 1.75, 2, nan])},
+                coords={"u": ("x", [nan, 0, nan, 1, nan, nan, nan, 2, nan])},
+            ),
+            id="Dataset-no units",
+        ),
+        pytest.param(
+            xr.Dataset(
+                {
+                    "a": (
+                        "x",
+                        Quantity([nan, 0, nan, 1, nan, nan, nan, 2, nan], "m"),
+                    )
+                },
+                coords={
+                    "u": (
+                        "x",
+                        Quantity([nan, 0, nan, 1, nan, nan, nan, 2, nan], "m"),
+                    )
+                },
+            ),
+            xr.Dataset(
+                {"a": ("x", Quantity([nan, 0, 0.5, 1, 1.25, 1.5, 1.75, 2, nan], "m"))},
+                coords={
+                    "u": (
+                        "x",
+                        Quantity([nan, 0, nan, 1, nan, nan, nan, 2, nan], "m"),
+                    )
+                },
+            ),
+            id="Dataset-units",
+        ),
+        pytest.param(
+            xr.DataArray(
+                [nan, 0, nan, 1, nan, nan, nan, 2, nan],
+                coords={
+                    "u": (
+                        "x",
+                        Quantity([nan, 0, nan, 1, nan, nan, nan, 2, nan], "m"),
+                    )
+                },
+                dims="x",
+            ),
+            xr.DataArray(
+                [nan, 0, 0.5, 1, 1.25, 1.5, 1.75, 2, nan],
+                coords={
+                    "u": (
+                        "x",
+                        Quantity([nan, 0, nan, 1, nan, nan, nan, 2, nan], "m"),
+                    )
+                },
+                dims="x",
+            ),
+            id="DataArray-units",
+        ),
+        pytest.param(
+            xr.DataArray(
+                Quantity([nan, 0, nan, 1, nan, nan, nan, 2, nan], "m"),
+                coords={
+                    "u": (
+                        "x",
+                        Quantity([nan, 0, nan, 1, nan, nan, nan, 2, nan], "m"),
+                    )
+                },
+                dims="x",
+            ),
+            xr.DataArray(
+                Quantity([nan, 0, 0.5, 1, 1.25, 1.5, 1.75, 2, nan], "m"),
+                coords={
+                    "u": (
+                        "x",
+                        Quantity([nan, 0, nan, 1, nan, nan, nan, 2, nan], "m"),
+                    )
+                },
+                dims="x",
+            ),
+            id="DataArray-units",
+        ),
+    ),
+)
+def test_interpolate_na(obj, expected):
+    actual = obj.pint.interpolate_na(dim="x")
+    assert_identical(actual, expected)
+    assert_units_equal(actual, expected)


### PR DESCRIPTION
`interpolate_na` is difficult to get to work without compatibility code (`np.interp` would need to gain support for `axis` and the `scipy` interpolation functions would need to start supporting duckarrays), so this adds a wrapper.

- [x] towards #70
- [x] Tests added
- [x] Passes `pre-commit run --all-files`
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [x] New functions/methods are listed in `api.rst`
