### PR TITLE
chunk

### DIFF
--- a/ci/requirements.txt
+++ b/ci/requirements.txt
@@ -1,6 +1,7 @@
 pint
 numpy
 scipy
+dask
 bottleneck
 xarray
 isort

--- a/ci/requirements.txt
+++ b/ci/requirements.txt
@@ -1,7 +1,7 @@
 pint
 numpy
 scipy
-dask
+dask[array]
 bottleneck
 xarray
 isort

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -28,6 +28,7 @@ Dataset
    xarray.Dataset.pint.drop_sel
    xarray.Dataset.pint.sel
    xarray.Dataset.pint.to
+   xarray.Dataset.pint.chunk
    xarray.Dataset.pint.ffill
    xarray.Dataset.pint.bfill
 
@@ -57,6 +58,7 @@ DataArray
    xarray.DataArray.pint.drop_sel
    xarray.DataArray.pint.sel
    xarray.DataArray.pint.to
+   xarray.DataArray.pint.chunk
    xarray.DataArray.pint.ffill
    xarray.DataArray.pint.bfill
 

--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -29,6 +29,8 @@ What's new
   By `Justus Magin <https://github.com/keewis>`_.
 - implement :py:meth:`Dataset.pint.drop_sel` and :py:meth:`DataArray.pint.drop_sel` (:pull:`73`).
   By `Justus Magin <https://github.com/keewis>`_.
+- implement :py:meth:`Dataset.pint.chunk` and :py:meth:`DataArray.pint.chunk` (:pull:`83`).
+  By `Justus Magin <https://github.com/keewis>`_.
 - implement :py:meth:`Dataset.pint.reindex`, :py:meth:`Dataset.pint.reindex_like`,
   :py:meth:`DataArray.pint.reindex` and :py:meth:`DataArray.pint.reindex_like` (:pull:`69`).
   By `Justus Magin <https://github.com/keewis>`_.

--- a/pint_xarray/accessors.py
+++ b/pint_xarray/accessors.py
@@ -569,6 +569,29 @@ class PintDataArrayAccessor:
 
         return conversion.convert_units(self.da, units)
 
+    def chunk(self, chunks, name_prefix="xarray-", token=None, lock=False):
+        """unit-aware version of chunk
+
+        Like :py:meth:`xarray.DataArray.chunk`, but chunking a quantity will change the
+        wrapped type to ``dask``.
+
+        .. note::
+            It is recommended to only use this when chunking in-memory arrays. To
+            rechunk please use :py:meth:`xarray.DataArray.chunk`.
+
+        See Also
+        --------
+        xarray.DataArray.chunk
+        xarray.Dataset.pint.chunk
+        """
+        units = conversion.extract_units(self.da)
+        stripped = conversion.strip_units(self.da)
+
+        chunked = stripped.chunk(
+            chunks, name_prefix=name_prefix, token=token, lock=lock
+        )
+        return conversion.attach_units(chunked, units)
+
     def reindex(
         self,
         indexers=None,
@@ -1266,6 +1289,29 @@ class PintDatasetAccessor:
         units = either_dict_or_kwargs(units, unit_kwargs, "to")
 
         return conversion.convert_units(self.ds, units)
+
+    def chunk(self, chunks, name_prefix="xarray-", token=None, lock=False):
+        """unit-aware version of chunk
+
+        Like :py:meth:`xarray.Dataset.chunk`, but chunking a quantity will change the
+        wrapped type to ``dask``.
+
+        .. note::
+            It is recommended to only use this when chunking in-memory arrays. To
+            rechunk please use :py:meth:`xarray.Dataset.chunk`.
+
+        See Also
+        --------
+        xarray.Dataset.chunk
+        xarray.DataArray.pint.chunk
+        """
+        units = conversion.extract_units(self.ds)
+        stripped = conversion.strip_units(self.ds)
+
+        chunked = stripped.chunk(
+            chunks, name_prefix=name_prefix, token=token, lock=lock
+        )
+        return conversion.attach_units(chunked, units)
 
     def reindex(
         self,

--- a/pint_xarray/tests/test_accessors.py
+++ b/pint_xarray/tests/test_accessors.py
@@ -1550,7 +1550,7 @@ def test_interp_like(obj, other, expected, error):
                 coords={
                     "u": (
                         "x",
-                        Quantity([nan, 0, nan, 1, nan, nan, 2, nan], "m"),
+                        [nan, 0, nan, 1, nan, nan, 2, nan],
                     )
                 },
                 dims="x",
@@ -1644,7 +1644,7 @@ def test_ffill(obj, expected):
                 coords={
                     "u": (
                         "x",
-                        Quantity([nan, 0, nan, 1, nan, nan, 2, nan], "m"),
+                        [nan, 0, nan, 1, nan, nan, 2, nan],
                     )
                 },
                 dims="x",

--- a/pint_xarray/tests/test_accessors.py
+++ b/pint_xarray/tests/test_accessors.py
@@ -847,7 +847,7 @@ def test_drop_sel(obj, indexers, expected, error):
                 coords={
                     "u": (
                         "x",
-                        Quantity(np.arange(11), "m"),
+                        np.arange(11),
                     )
                 },
                 dims="x",
@@ -871,7 +871,10 @@ def test_drop_sel(obj, indexers, expected, error):
 )
 def test_chunk(obj):
     actual = obj.pint.chunk({"x": 2})
-    expected = obj.pint.dequantify().chunk({"x": 2}).pint.quantify()
+
+    expected = (
+        obj.pint.dequantify().chunk({"x": 2}).pint.quantify(unit_registry=unit_registry)
+    )
 
     assert_units_equal(actual, expected)
     assert_identical(actual, expected)

--- a/pint_xarray/tests/test_accessors.py
+++ b/pint_xarray/tests/test_accessors.py
@@ -815,6 +815,69 @@ def test_drop_sel(obj, indexers, expected, error):
 
 
 @pytest.mark.parametrize(
+    "obj",
+    (
+        pytest.param(
+            xr.Dataset(
+                {"a": ("x", np.linspace(0, 1, 11))},
+                coords={"u": ("x", np.arange(11))},
+            ),
+            id="Dataset-no units",
+        ),
+        pytest.param(
+            xr.Dataset(
+                {
+                    "a": (
+                        "x",
+                        Quantity(np.linspace(0, 1, 11), "m"),
+                    )
+                },
+                coords={
+                    "u": (
+                        "x",
+                        Quantity(np.arange(11), "m"),
+                    )
+                },
+            ),
+            id="Dataset-units",
+        ),
+        pytest.param(
+            xr.DataArray(
+                np.linspace(0, 1, 11),
+                coords={
+                    "u": (
+                        "x",
+                        Quantity(np.arange(11), "m"),
+                    )
+                },
+                dims="x",
+            ),
+            id="DataArray-no units",
+        ),
+        pytest.param(
+            xr.DataArray(
+                Quantity(np.linspace(0, 1, 11), "m"),
+                coords={
+                    "u": (
+                        "x",
+                        Quantity(np.arange(11), "m"),
+                    )
+                },
+                dims="x",
+            ),
+            id="DataArray-units",
+        ),
+    ),
+)
+def test_chunk(obj):
+    actual = obj.pint.chunk({"x": 2})
+    expected = obj.pint.dequantify().chunk({"x": 2}).pint.quantify()
+
+    assert_units_equal(actual, expected)
+    assert_identical(actual, expected)
+
+
+@pytest.mark.parametrize(
     ["obj", "indexers", "expected", "error"],
     (
         pytest.param(

--- a/pint_xarray/tests/test_accessors.py
+++ b/pint_xarray/tests/test_accessors.py
@@ -1494,12 +1494,12 @@ def test_interp_like(obj, other, expected, error):
                 coords={
                     "u": (
                         "x",
-                        Quantity([nan, 0, nan, 1, nan, nan, 2, nan], "m"),
+                        [nan, 0, nan, 1, nan, nan, 2, nan],
                     )
                 },
                 dims="x",
             ),
-            id="DataArray-units",
+            id="DataArray-no units",
         ),
         pytest.param(
             xr.DataArray(
@@ -1588,12 +1588,12 @@ def test_ffill(obj, expected):
                 coords={
                     "u": (
                         "x",
-                        Quantity([nan, 0, nan, 1, nan, nan, 2, nan], "m"),
+                        [nan, 0, nan, 1, nan, nan, 2, nan],
                     )
                 },
                 dims="x",
             ),
-            id="DataArray-units",
+            id="DataArray-no units",
         ),
         pytest.param(
             xr.DataArray(


### PR DESCRIPTION
This adds a unit-aware version of `chunk` (more specifically, it avoids using `dask.array.from_array` on `pint.Quantity`)

- [x] towards #70
- [x] Tests added
- [x] Passes `pre-commit run --all-files`
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [x] New functions/methods are listed in `api.rst`
