### PR TITLE
expose setup_registry

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -6,6 +6,7 @@ This page contains a auto-generated summary of ``pint-xarray``'s API.
    :toctree: generated/
 
    pint_xarray.unit_registry
+   pint_xarray.setup_registry
 
 Dataset
 -------

--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -42,6 +42,8 @@ What's new
   By `Justus Magin <https://github.com/keewis>`_.
 - implement :py:meth:`Dataset.pint.interpolate_na` and :py:meth:`DataArray.pint.interpolate_na` (:pull:`82`).
   By `Justus Magin <https://github.com/keewis>`_.
+- expose :py:func:`pint_xarray.accessors.setup_registry` as public API (:pull:`89`)
+  By `Justus Magin <https://github.com/keewis>`_.
 
 v0.1 (October 26 2020)
 ----------------------

--- a/pint_xarray/__init__.py
+++ b/pint_xarray/__init__.py
@@ -19,3 +19,9 @@ except Exception:
 
 
 pint.Quantity._repr_inline_ = formatting.inline_repr
+
+
+__all__ = [
+    "testing",
+    "unit_registry",
+]

--- a/pint_xarray/__init__.py
+++ b/pint_xarray/__init__.py
@@ -5,10 +5,9 @@ except ImportError:
 
 import pint
 
-from . import testing  # noqa: F401
-from . import formatting
-from .accessors import PintDataArrayAccessor, PintDatasetAccessor  # noqa: F401
-from .accessors import default_registry as unit_registry  # noqa: F401
+from . import accessors, formatting, testing  # noqa: F401
+from .accessors import default_registry as unit_registry
+from .accessors import setup_registry
 
 try:
     __version__ = version("pint-xarray")
@@ -24,4 +23,5 @@ pint.Quantity._repr_inline_ = formatting.inline_repr
 __all__ = [
     "testing",
     "unit_registry",
+    "setup_registry",
 ]

--- a/pint_xarray/accessors.py
+++ b/pint_xarray/accessors.py
@@ -1033,7 +1033,8 @@ class PintDataArrayAccessor:
     ):
         """unit-aware version of interpolate_na
 
-        Like :py:meth:`DataArray.interpolate_na` but without stripping the units on data or coordinates.
+        Like :py:meth:`xarray.DataArray.interpolate_na` but without stripping the units
+        on data or coordinates.
 
         .. note::
             ``max_gap`` is not supported, yet, and will be passed through to
@@ -1794,7 +1795,8 @@ class PintDatasetAccessor:
     ):
         """unit-aware version of interpolate_na
 
-        Like :py:meth:`Dataset.interpolate_na` but without stripping the units on data or coordinates.
+        Like :py:meth:`xarray.Dataset.interpolate_na` but without stripping the units on
+        data or coordinates.
 
         .. note::
             ``max_gap`` is not supported, yet, and will be passed through to


### PR DESCRIPTION
This exposes `setup_registry` so it is possible to setup a custom registry without caring too much about the exact list of registry options `pint_xarray` requires.

- [x] Passes `pre-commit run --all-files`
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [x] New functions/methods are listed in `api.rst`
