### PR TITLE
provide more context to errors

### DIFF
--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -8,9 +8,9 @@ What's new
 - rewrite :py:meth:`Dataset.pint.quantify` and :py:meth:`DataArray.pint.quantify`,
   to use pint's `parse_units` instead of `parse_expression` (:pull:`40`)
   By `Tom Nicholas <https://github.com/TomNicholas>`_.
-- ensure the variable which causes the error is explicit if an error occurs in
-  :py:meth:`Dataset.pint.quantify` (:pull:`43`)
-  By `Tom Nicholas <https://github.com/TomNicholas>`_.
+- ensure the variables which causes the error is explicit if an error occurs in
+  :py:meth:`Dataset.pint.quantify` and other methods (:pull:`43`, :pull:`91`)
+  By `Tom Nicholas <https://github.com/TomNicholas>`_ and `Justus Magin <https://github.com/keewis>`_.
 - refactor the internal conversion functions (:pull:`56`)
   By `Justus Magin <https://github.com/keewis>`_.
 - allow converting indexes (except :py:class:`pandas.MultiIndex`) (:pull:`56`)

--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -45,7 +45,7 @@ What's new
   By `Justus Magin <https://github.com/keewis>`_.
 - implement :py:meth:`Dataset.pint.interpolate_na` and :py:meth:`DataArray.pint.interpolate_na` (:pull:`82`).
   By `Justus Magin <https://github.com/keewis>`_.
-- expose :py:func:`pint_xarray.accessors.setup_registry` as public API (:pull:`89`)
+- expose :py:func:`pint_xarray.setup_registry` as public API (:pull:`89`)
   By `Justus Magin <https://github.com/keewis>`_.
 
 v0.1 (October 26 2020)

--- a/pint_xarray/accessors.py
+++ b/pint_xarray/accessors.py
@@ -143,7 +143,7 @@ def _decide_units(units, registry, unit_attribute):
         # TODO and what happens if they pass in a Unit from a different registry
         pass
     else:
-        units = registry.Unit(units)
+        units = registry.parse_units(units)
     return units
 
 

--- a/pint_xarray/accessors.py
+++ b/pint_xarray/accessors.py
@@ -632,36 +632,15 @@ class PintDataArrayAccessor:
         """
         indexers = either_dict_or_kwargs(indexers, indexers_kwargs, "reindex")
 
+        dims = self.da.dims
         indexer_units = {
             name: conversion.extract_indexer_units(indexer)
             for name, indexer in indexers.items()
+            if name in dims
         }
 
         # TODO: handle tolerance
         # TODO: handle fill_value
-
-        # make sure we only have compatible units
-        dims = self.da.dims
-        unit_attrs = conversion.extract_unit_attributes(self.da)
-        index_units = {
-            name: units for name, units in unit_attrs.items() if name in dims
-        }
-
-        registry = get_registry(None, index_units, indexer_units)
-
-        units = zip_mappings(indexer_units, index_units)
-        incompatible_units = [
-            key
-            for key, (indexer_unit, index_unit) in units.items()
-            if (
-                None not in (indexer_unit, index_unit)
-                and not registry.is_compatible_with(indexer_unit, index_unit)
-            )
-        ]
-        if incompatible_units:
-            units1 = {key: indexer_units[key] for key in incompatible_units}
-            units2 = {key: index_units[key] for key in incompatible_units}
-            raise DimensionalityError(units1, units2)
 
         # convert the indexes to the indexer's units
         converted = conversion.convert_units(self.da, indexer_units)
@@ -1406,36 +1385,15 @@ class PintDatasetAccessor:
         """
         indexers = either_dict_or_kwargs(indexers, indexers_kwargs, "reindex")
 
+        dims = self.ds.dims
         indexer_units = {
             name: conversion.extract_indexer_units(indexer)
             for name, indexer in indexers.items()
+            if name in dims
         }
 
         # TODO: handle tolerance
         # TODO: handle fill_value
-
-        # make sure we only have compatible units
-        dims = self.ds.dims
-        unit_attrs = conversion.extract_unit_attributes(self.ds)
-        index_units = {
-            name: units for name, units in unit_attrs.items() if name in dims
-        }
-
-        registry = get_registry(None, index_units, indexer_units)
-
-        units = zip_mappings(indexer_units, index_units)
-        incompatible_units = [
-            key
-            for key, (indexer_unit, index_unit) in units.items()
-            if (
-                None not in (indexer_unit, index_unit)
-                and not registry.is_compatible_with(indexer_unit, index_unit)
-            )
-        ]
-        if incompatible_units:
-            units1 = {key: indexer_units[key] for key in incompatible_units}
-            units2 = {key: index_units[key] for key in incompatible_units}
-            raise DimensionalityError(units1, units2)
 
         # convert the indexes to the indexer's units
         converted = conversion.convert_units(self.ds, indexer_units)

--- a/pint_xarray/accessors.py
+++ b/pint_xarray/accessors.py
@@ -8,7 +8,7 @@ from xarray import register_dataarray_accessor, register_dataset_accessor
 from xarray.core.dtypes import NA
 
 from . import conversion
-from .errors import DimensionalityError, format_error_message
+from .errors import format_error_message
 
 
 def setup_registry(registry):
@@ -157,41 +157,18 @@ class DatasetLocIndexer:
         if not is_dict_like(indexers):
             raise NotImplementedError("pandas-style indexing is not supported, yet")
 
+        dims = self.ds.dims
         indexer_units = {
             name: conversion.extract_indexer_units(indexer)
             for name, indexer in indexers.items()
+            if name in dims
         }
-
-        # make sure we only have compatible units
-        dims = self.ds.dims
-        unit_attrs = conversion.extract_unit_attributes(self.ds)
-        index_units = {
-            name: units for name, units in unit_attrs.items() if name in dims
-        }
-
-        registry = get_registry(None, index_units, indexer_units)
-
-        units = zip_mappings(indexer_units, index_units)
-        incompatible_units = [
-            key
-            for key, (indexer_unit, index_unit) in units.items()
-            if (
-                None not in (indexer_unit, index_unit)
-                and not registry.is_compatible_with(indexer_unit, index_unit)
-            )
-        ]
-        if incompatible_units:
-            raise KeyError(
-                "not all values found in "
-                + (
-                    f"index {incompatible_units[0]!r}"
-                    if len(incompatible_units) == 1
-                    else f"indexes {', '.join(repr(_) for _ in incompatible_units)}"
-                )
-            )
 
         # convert the indexes to the indexer's units
-        converted = conversion.convert_units(self.ds, indexer_units)
+        try:
+            converted = conversion.convert_units(self.ds, indexer_units)
+        except ValueError as e:
+            raise KeyError(*e.args) from e
 
         # index
         stripped_indexers = {
@@ -211,41 +188,18 @@ class DataArrayLocIndexer:
         if not is_dict_like(indexers):
             raise NotImplementedError("pandas-style indexing is not supported, yet")
 
+        dims = self.da.dims
         indexer_units = {
             name: conversion.extract_indexer_units(indexer)
             for name, indexer in indexers.items()
+            if name in dims
         }
-
-        # make sure we only have compatible units
-        dims = self.da.dims
-        unit_attrs = conversion.extract_unit_attributes(self.da)
-        index_units = {
-            name: units for name, units in unit_attrs.items() if name in dims
-        }
-
-        registry = get_registry(None, index_units, indexer_units)
-
-        units = zip_mappings(indexer_units, index_units)
-        incompatible_units = [
-            key
-            for key, (indexer_unit, index_unit) in units.items()
-            if (
-                None not in (indexer_unit, index_unit)
-                and not registry.is_compatible_with(indexer_unit, index_unit)
-            )
-        ]
-        if incompatible_units:
-            raise KeyError(
-                "not all values found in "
-                + (
-                    f"index {incompatible_units[0]!r}"
-                    if len(incompatible_units) == 1
-                    else f"indexes {', '.join(repr(_) for _ in incompatible_units)}"
-                )
-            )
 
         # convert the indexes to the indexer's units
-        converted = conversion.convert_units(self.da, indexer_units)
+        try:
+            converted = conversion.convert_units(self.da, indexer_units)
+        except ValueError as e:
+            raise KeyError(*e.args) from e
 
         # index
         stripped_indexers = {
@@ -258,44 +212,17 @@ class DataArrayLocIndexer:
         if not is_dict_like(indexers):
             raise NotImplementedError("pandas-style indexing is not supported, yet")
 
-        indexer_units = {
-            name: conversion.extract_indexer_units(indexer)
-            for name, indexer in indexers.items()
-        }
-
-        # make sure we only have compatible units
         dims = self.da.dims
         unit_attrs = conversion.extract_unit_attributes(self.da)
         index_units = {
             name: units for name, units in unit_attrs.items() if name in dims
         }
 
-        registry = get_registry(None, index_units, indexer_units)
-
-        units = zip_mappings(indexer_units, index_units)
-        incompatible_units = [
-            key
-            for key, (indexer_unit, index_unit) in units.items()
-            if (
-                None not in (indexer_unit, index_unit)
-                and not registry.is_compatible_with(indexer_unit, index_unit)
-            )
-        ]
-        if incompatible_units:
-            raise KeyError(
-                "not all values found in "
-                + (
-                    f"index {incompatible_units[0]!r}"
-                    if len(incompatible_units) == 1
-                    else f"indexes {', '.join(repr(_) for _ in incompatible_units)}"
-                )
-            )
-
         # convert the indexers to the index units
-        converted = {
-            name: conversion.convert_indexer_units(indexer, index_units[name])
-            for name, indexer in indexers.items()
-        }
+        try:
+            converted = conversion.convert_indexer_units(indexers, index_units)
+        except ValueError as e:
+            raise KeyError(*e.args) from e
 
         # index
         stripped_indexers = {
@@ -414,7 +341,7 @@ class PintDataArrayAccessor:
             raise ValueError(format_error_message(invalid_units, "parse"))
 
         return self.da.pipe(conversion.strip_unit_attributes).pipe(
-            conversion.attach_units, units
+            conversion.attach_units, new_units
         )
 
     def dequantify(self, format=None):
@@ -682,29 +609,6 @@ class PintDataArrayAccessor:
         # TODO: handle tolerance
         # TODO: handle fill_value
 
-        # make sure we only have compatible units
-        dims = self.da.dims
-        unit_attrs = conversion.extract_unit_attributes(self.da)
-        index_units = {
-            name: units for name, units in unit_attrs.items() if name in dims
-        }
-
-        registry = get_registry(None, index_units, indexer_units)
-
-        units = zip_mappings(indexer_units, index_units)
-        incompatible_units = [
-            key
-            for key, (indexer_unit, index_unit) in units.items()
-            if (
-                None not in (indexer_unit, index_unit)
-                and not registry.is_compatible_with(indexer_unit, index_unit)
-            )
-        ]
-        if incompatible_units:
-            units1 = {key: indexer_units[key] for key in incompatible_units}
-            units2 = {key: index_units[key] for key in incompatible_units}
-            raise DimensionalityError(units1, units2)
-
         converted = conversion.convert_units(self.da, indexer_units)
         return converted.reindex_like(
             other,
@@ -738,33 +642,12 @@ class PintDataArrayAccessor:
         """
         indexers = either_dict_or_kwargs(coords, coords_kwargs, "interp")
 
+        dims = self.da.dims
         indexer_units = {
             name: conversion.extract_indexer_units(indexer)
             for name, indexer in indexers.items()
+            if name in dims
         }
-
-        # make sure we only have compatible units
-        dims = self.da.dims
-        unit_attrs = conversion.extract_unit_attributes(self.da)
-        index_units = {
-            name: units for name, units in unit_attrs.items() if name in dims
-        }
-
-        registry = get_registry(None, index_units, indexer_units)
-
-        units = zip_mappings(indexer_units, index_units)
-        incompatible_units = [
-            key
-            for key, (indexer_unit, index_unit) in units.items()
-            if (
-                None not in (indexer_unit, index_unit)
-                and not registry.is_compatible_with(indexer_unit, index_unit)
-            )
-        ]
-        if incompatible_units:
-            units1 = {key: indexer_units[key] for key in incompatible_units}
-            units2 = {key: index_units[key] for key in incompatible_units}
-            raise DimensionalityError(units1, units2)
 
         # convert the indexes to the indexer's units
         converted = conversion.convert_units(self.da, indexer_units)
@@ -801,29 +684,6 @@ class PintDataArrayAccessor:
         """
         indexer_units = conversion.extract_unit_attributes(other)
 
-        # make sure we only have compatible units
-        dims = self.da.dims
-        unit_attrs = conversion.extract_unit_attributes(self.da)
-        index_units = {
-            name: units for name, units in unit_attrs.items() if name in dims
-        }
-
-        registry = get_registry(None, index_units, indexer_units)
-
-        units = zip_mappings(indexer_units, index_units)
-        incompatible_units = [
-            key
-            for key, (indexer_unit, index_unit) in units.items()
-            if (
-                None not in (indexer_unit, index_unit)
-                and not registry.is_compatible_with(indexer_unit, index_unit)
-            )
-        ]
-        if incompatible_units:
-            units1 = {key: indexer_units[key] for key in incompatible_units}
-            units2 = {key: index_units[key] for key in incompatible_units}
-            raise DimensionalityError(units1, units2)
-
         converted = conversion.convert_units(self.da, indexer_units)
         units = conversion.extract_units(converted)
         stripped = conversion.strip_units(converted)
@@ -855,43 +715,20 @@ class PintDataArrayAccessor:
         """
         indexers = either_dict_or_kwargs(indexers, indexers_kwargs, "sel")
 
+        dims = self.da.dims
         indexer_units = {
             name: conversion.extract_indexer_units(indexer)
             for name, indexer in indexers.items()
+            if name in dims
         }
 
         # TODO: handle tolerance
 
-        # make sure we only have compatible units
-        dims = self.da.dims
-        unit_attrs = conversion.extract_unit_attributes(self.da)
-        index_units = {
-            name: units for name, units in unit_attrs.items() if name in dims
-        }
-
-        registry = get_registry(None, index_units, indexer_units)
-
-        units = zip_mappings(indexer_units, index_units)
-        incompatible_units = [
-            key
-            for key, (indexer_unit, index_unit) in units.items()
-            if (
-                None not in (indexer_unit, index_unit)
-                and not registry.is_compatible_with(indexer_unit, index_unit)
-            )
-        ]
-        if incompatible_units:
-            raise KeyError(
-                "not all values found in "
-                + (
-                    f"index {incompatible_units[0]!r}"
-                    if len(incompatible_units) == 1
-                    else f"indexes {', '.join(repr(_) for _ in incompatible_units)}"
-                )
-            )
-
         # convert the indexes to the indexer's units
-        converted = conversion.convert_units(self.da, indexer_units)
+        try:
+            converted = conversion.convert_units(self.da, indexer_units)
+        except ValueError as e:
+            raise KeyError(*e.args) from e
 
         # index
         stripped_indexers = {
@@ -934,39 +771,17 @@ class PintDataArrayAccessor:
         """
         indexers = either_dict_or_kwargs(labels, labels_kwargs, "drop_sel")
 
-        indexer_units = {
-            name: conversion.extract_indexer_units(indexer)
-            for name, indexer in indexers.items()
-        }
-
-        # make sure we only have compatible units
         dims = self.da.dims
         unit_attrs = conversion.extract_unit_attributes(self.da)
         index_units = {
             name: units for name, units in unit_attrs.items() if name in dims
         }
 
-        registry = get_registry(None, index_units, indexer_units)
-
-        units = zip_mappings(indexer_units, index_units)
-        incompatible_units = [
-            key
-            for key, (indexer_unit, index_unit) in units.items()
-            if (
-                None not in (indexer_unit, index_unit)
-                and not registry.is_compatible_with(indexer_unit, index_unit)
-            )
-        ]
-        if incompatible_units:
-            units1 = {key: indexer_units[key] for key in incompatible_units}
-            units2 = {key: index_units[key] for key in incompatible_units}
-            raise DimensionalityError(units1, units2)
-
         # convert the indexers to the indexes units
-        converted_indexers = {
-            name: conversion.convert_indexer_units(indexer, index_units[name])
-            for name, indexer in indexers.items()
-        }
+        try:
+            converted_indexers = conversion.convert_indexer_units(indexers, index_units)
+        except ValueError as e:
+            raise KeyError(*e.args) from e
 
         # index
         stripped_indexers = {
@@ -1435,29 +1250,6 @@ class PintDatasetAccessor:
         # TODO: handle tolerance
         # TODO: handle fill_value
 
-        # make sure we only have compatible units
-        dims = self.ds.dims
-        unit_attrs = conversion.extract_unit_attributes(self.ds)
-        index_units = {
-            name: units for name, units in unit_attrs.items() if name in dims
-        }
-
-        registry = get_registry(None, index_units, indexer_units)
-
-        units = zip_mappings(indexer_units, index_units)
-        incompatible_units = [
-            key
-            for key, (indexer_unit, index_unit) in units.items()
-            if (
-                None not in (indexer_unit, index_unit)
-                and not registry.is_compatible_with(indexer_unit, index_unit)
-            )
-        ]
-        if incompatible_units:
-            units1 = {key: indexer_units[key] for key in incompatible_units}
-            units2 = {key: index_units[key] for key in incompatible_units}
-            raise DimensionalityError(units1, units2)
-
         converted = conversion.convert_units(self.ds, indexer_units)
         return converted.reindex_like(
             other,
@@ -1491,33 +1283,12 @@ class PintDatasetAccessor:
         """
         indexers = either_dict_or_kwargs(coords, coords_kwargs, "interp")
 
+        dims = self.ds.dims
         indexer_units = {
             name: conversion.extract_indexer_units(indexer)
             for name, indexer in indexers.items()
+            if name in dims
         }
-
-        # make sure we only have compatible units
-        dims = self.ds.dims
-        unit_attrs = conversion.extract_unit_attributes(self.ds)
-        index_units = {
-            name: units for name, units in unit_attrs.items() if name in dims
-        }
-
-        registry = get_registry(None, index_units, indexer_units)
-
-        units = zip_mappings(indexer_units, index_units)
-        incompatible_units = [
-            key
-            for key, (indexer_unit, index_unit) in units.items()
-            if (
-                None not in (indexer_unit, index_unit)
-                and not registry.is_compatible_with(indexer_unit, index_unit)
-            )
-        ]
-        if incompatible_units:
-            units1 = {key: indexer_units[key] for key in incompatible_units}
-            units2 = {key: index_units[key] for key in incompatible_units}
-            raise DimensionalityError(units1, units2)
 
         # convert the indexes to the indexer's units
         converted = conversion.convert_units(self.ds, indexer_units)
@@ -1554,29 +1325,6 @@ class PintDatasetAccessor:
         """
         indexer_units = conversion.extract_unit_attributes(other)
 
-        # make sure we only have compatible units
-        dims = self.ds.dims
-        unit_attrs = conversion.extract_unit_attributes(self.ds)
-        index_units = {
-            name: units for name, units in unit_attrs.items() if name in dims
-        }
-
-        registry = get_registry(None, index_units, indexer_units)
-
-        units = zip_mappings(indexer_units, index_units)
-        incompatible_units = [
-            key
-            for key, (indexer_unit, index_unit) in units.items()
-            if (
-                None not in (indexer_unit, index_unit)
-                and not registry.is_compatible_with(indexer_unit, index_unit)
-            )
-        ]
-        if incompatible_units:
-            units1 = {key: indexer_units[key] for key in incompatible_units}
-            units2 = {key: index_units[key] for key in incompatible_units}
-            raise DimensionalityError(units1, units2)
-
         converted = conversion.convert_units(self.ds, indexer_units)
         units = conversion.extract_units(converted)
         stripped = conversion.strip_units(converted)
@@ -1608,43 +1356,20 @@ class PintDatasetAccessor:
         """
         indexers = either_dict_or_kwargs(indexers, indexers_kwargs, "sel")
 
+        dims = self.ds.dims
         indexer_units = {
             name: conversion.extract_indexer_units(indexer)
             for name, indexer in indexers.items()
+            if name in dims
         }
 
         # TODO: handle tolerance
 
-        # make sure we only have compatible units
-        dims = self.ds.dims
-        unit_attrs = conversion.extract_unit_attributes(self.ds)
-        index_units = {
-            name: units for name, units in unit_attrs.items() if name in dims
-        }
-
-        registry = get_registry(None, index_units, indexer_units)
-
-        units = zip_mappings(indexer_units, index_units)
-        incompatible_units = [
-            key
-            for key, (indexer_unit, index_unit) in units.items()
-            if (
-                None not in (indexer_unit, index_unit)
-                and not registry.is_compatible_with(indexer_unit, index_unit)
-            )
-        ]
-        if incompatible_units:
-            raise KeyError(
-                "not all values found in "
-                + (
-                    f"index {incompatible_units[0]!r}"
-                    if len(incompatible_units) == 1
-                    else f"indexes {', '.join(repr(_) for _ in incompatible_units)}"
-                )
-            )
-
         # convert the indexes to the indexer's units
-        converted = conversion.convert_units(self.ds, indexer_units)
+        try:
+            converted = conversion.convert_units(self.ds, indexer_units)
+        except ValueError as e:
+            raise KeyError(*e.args) from e
 
         # index
         stripped_indexers = {
@@ -1689,39 +1414,17 @@ class PintDatasetAccessor:
         """
         indexers = either_dict_or_kwargs(labels, labels_kwargs, "drop_sel")
 
-        indexer_units = {
-            name: conversion.extract_indexer_units(indexer)
-            for name, indexer in indexers.items()
-        }
-
-        # make sure we only have compatible units
         dims = self.ds.dims
         unit_attrs = conversion.extract_unit_attributes(self.ds)
         index_units = {
             name: units for name, units in unit_attrs.items() if name in dims
         }
 
-        registry = get_registry(None, index_units, indexer_units)
-
-        units = zip_mappings(indexer_units, index_units)
-        incompatible_units = [
-            key
-            for key, (indexer_unit, index_unit) in units.items()
-            if (
-                None not in (indexer_unit, index_unit)
-                and not registry.is_compatible_with(indexer_unit, index_unit)
-            )
-        ]
-        if incompatible_units:
-            units1 = {key: indexer_units[key] for key in incompatible_units}
-            units2 = {key: index_units[key] for key in incompatible_units}
-            raise DimensionalityError(units1, units2)
-
         # convert the indexers to the indexes units
-        converted_indexers = {
-            name: conversion.convert_indexer_units(indexer, index_units[name])
-            for name, indexer in indexers.items()
-        }
+        try:
+            converted_indexers = conversion.convert_indexer_units(indexers, index_units)
+        except ValueError as e:
+            raise KeyError(*e.args) from e
 
         # index
         stripped_indexers = {

--- a/pint_xarray/accessors.py
+++ b/pint_xarray/accessors.py
@@ -327,7 +327,7 @@ class PintDataArrayAccessor:
             if unit is not None or attr is not None:
                 try:
                     new_units[name] = _decide_units(unit, registry, attr)
-                except Exception as e:
+                except (ValueError, pint.UndefinedUnitError) as e:
                     if unit is not None:
                         type = "parameter"
                         reported_unit = unit
@@ -960,7 +960,7 @@ class PintDatasetAccessor:
             if unit is not None or attr is not None:
                 try:
                     new_units[name] = _decide_units(unit, registry, attr)
-                except Exception as e:
+                except (ValueError, pint.UndefinedUnitError) as e:
                     if unit is not None:
                         type = "parameter"
                         reported_unit = unit

--- a/pint_xarray/conversion.py
+++ b/pint_xarray/conversion.py
@@ -3,6 +3,8 @@ import itertools
 import pint
 from xarray import DataArray, Dataset, IndexVariable, Variable
 
+from .errors import format_error_message
+
 unit_attribute_name = "units"
 slice_attributes = ("start", "stop", "step")
 
@@ -116,15 +118,24 @@ def attach_units(obj, units):
         new_ds = attach_units(ds, units)
         new_obj = new_ds.get(new_name).rename(old_name)
     elif isinstance(obj, Dataset):
+        attached = {}
+        rejected_vars = {}
+        for name, var in obj.variables.items():
+            unit = units.get(name)
+            try:
+                converted = attach_units_variable(var, unit)
+                attached[name] = converted
+            except ValueError as e:
+                rejected_vars[name] = (unit, e)
+
+        if rejected_vars:
+            raise ValueError(format_error_message(rejected_vars, "attach"))
+
         data_vars = {
-            name: attach_units_variable(var, units.get(name))
-            for name, var in obj.variables.items()
-            if name not in obj._coord_names
+            name: var for name, var in attached.items() if name not in obj._coord_names
         }
         coords = {
-            name: attach_units_variable(var, units.get(name))
-            for name, var in obj.variables.items()
-            if name in obj._coord_names
+            name: var for name, var in attached.items() if name in obj._coord_names
         }
 
         new_obj = Dataset(data_vars=data_vars, coords=coords, attrs=obj.attrs)
@@ -191,16 +202,23 @@ def convert_units(obj, units):
 
         new_obj = converted[name].rename(original_name)
     elif isinstance(obj, Dataset):
-        coords = {
-            name: convert_units_variable(variable, units.get(name))
-            for name, variable in obj.variables.items()
-            if name in obj._coord_names
-        }
+        converted = {}
+        failed = {}
+        for name, var in obj.variables.items():
+            unit = units.get(name)
+            try:
+                converted[name] = convert_units_variable(var, unit)
+            except (ValueError, pint.errors.PintTypeError) as e:
+                failed[name] = e
 
+        if failed:
+            raise ValueError(format_error_message(failed, "convert"))
+
+        coords = {
+            name: var for name, var in converted.items() if name in obj._coord_names
+        }
         data_vars = {
-            name: convert_units_variable(variable, units.get(name))
-            for name, variable in obj.variables.items()
-            if name not in obj._coord_names
+            name: var for name, var in converted.items() if name not in obj._coord_names
         }
 
         new_obj = Dataset(data_vars=data_vars, coords=coords, attrs=obj.attrs)

--- a/pint_xarray/errors.py
+++ b/pint_xarray/errors.py
@@ -1,6 +1,41 @@
 import pint
 
 
+def format_error_message(mapping, op):
+    sep = "\n    " if len(mapping) == 1 else "\n -- "
+    if op == "attach":
+        message = "Cannot attach units:"
+        message = sep.join(
+            [message]
+            + [
+                f"cannot attach units to variable {key!r}: {unit} (reason: {str(e)})"
+                for key, (unit, e) in mapping.items()
+            ]
+        )
+    elif op == "parse":
+        message = "Cannot parse units:"
+        message = sep.join(
+            [message]
+            + [
+                f"invalid units for variable {key!r}: {unit} ({type}) (reason: {str(e)})"
+                for key, (unit, type, e) in mapping.items()
+            ]
+        )
+    elif op == "convert":
+        message = "Cannot convert variables:"
+        message = sep.join(
+            [message]
+            + [
+                f"incompatible units for variable {key!r}: {error}"
+                for key, error in mapping.items()
+            ]
+        )
+    else:
+        raise ValueError("invalid op")
+
+    return message
+
+
 class DimensionalityError(pint.DimensionalityError):
     """Raised when trying to convert between incompatible units
 
@@ -36,34 +71,4 @@ class DimensionalityError(pint.DimensionalityError):
                 for key, (u1, u2) in incompatible_units.items()
             ]
         )
-        return message
-
-
-class UnitParsingError(ValueError):
-    """Raised when parsing units fails
-
-    Parameters
-    ----------
-    invalid_units : mapping of hashable to tuple of unit-like, str and exception
-        The rejected units
-    """
-
-    def __init__(self, invalid_units):
-        if not invalid_units:
-            raise ValueError("no units given")
-        self.invalid_units = invalid_units
-
-    def __str__(self):
-        invalid_units = self.invalid_units
-
-        message = "Cannot parse units:"
-        sep = "\n    " if len(invalid_units) == 1 else "\n -- "
-        message = sep.join(
-            [message]
-            + [
-                f"invalid units for variable {key!r}: {unit} ({type}) (reason: {str(e)})"
-                for key, (unit, type, e) in invalid_units.items()
-            ]
-        )
-
         return message

--- a/pint_xarray/errors.py
+++ b/pint_xarray/errors.py
@@ -27,11 +27,7 @@ class DimensionalityError(pint.DimensionalityError):
         incompatible_units = self.incompatible_units
 
         message = "Cannot convert some variables:"
-        if len(incompatible_units) == 1:
-            sep = ""
-            message += " "
-        else:
-            sep = "\n -- "
+        sep = " " if len(incompatible_units) == 1 else "\n -- "
 
         message = sep.join(
             [message]

--- a/pint_xarray/errors.py
+++ b/pint_xarray/errors.py
@@ -14,10 +14,10 @@ class DimensionalityError(pint.DimensionalityError):
     """
 
     def __init__(self, units1, units2):
-        if units1.keys() != units2.keys():
-            raise ValueError("units1 and units2 must have the same keys")
-        elif not units1:
+        if not units1:
             raise ValueError("no units given")
+        elif units1.keys() != units2.keys():
+            raise ValueError("units1 and units2 must have the same keys")
 
         self.incompatible_units = {
             key: (units1[key], units2[key]) for key in units1.keys()

--- a/pint_xarray/errors.py
+++ b/pint_xarray/errors.py
@@ -30,6 +30,15 @@ def format_error_message(mapping, op):
                 for key, error in mapping.items()
             ]
         )
+    elif op == "convert_indexers":
+        message = "Cannot convert indexers:"
+        message = sep.join(
+            [message]
+            + [
+                f"incompatible units for indexer for {key!r}: {error}"
+                for key, error in mapping.items()
+            ]
+        )
     else:
         raise ValueError("invalid op")
 

--- a/pint_xarray/errors.py
+++ b/pint_xarray/errors.py
@@ -37,3 +37,33 @@ class DimensionalityError(pint.DimensionalityError):
             ]
         )
         return message
+
+
+class UnitParsingError(ValueError):
+    """Raised when parsing units fails
+
+    Parameters
+    ----------
+    invalid_units : mapping of hashable to tuple of unit-like, str and exception
+        The rejected units
+    """
+
+    def __init__(self, invalid_units):
+        if not invalid_units:
+            raise ValueError("no units given")
+        self.invalid_units = invalid_units
+
+    def __str__(self):
+        invalid_units = self.invalid_units
+
+        message = "Cannot parse units:"
+        sep = "\n    " if len(invalid_units) == 1 else "\n -- "
+        message = sep.join(
+            [message]
+            + [
+                f"invalid units for variable {key!r}: {unit} ({type}) (reason: {str(e)})"
+                for key, (unit, type, e) in invalid_units.items()
+            ]
+        )
+
+        return message

--- a/pint_xarray/errors.py
+++ b/pint_xarray/errors.py
@@ -1,6 +1,3 @@
-import pint
-
-
 def format_error_message(mapping, op):
     sep = "\n    " if len(mapping) == 1 else "\n -- "
     if op == "attach":
@@ -43,41 +40,3 @@ def format_error_message(mapping, op):
         raise ValueError("invalid op")
 
     return message
-
-
-class DimensionalityError(pint.DimensionalityError):
-    """Raised when trying to convert between incompatible units
-
-    Parameters
-    ----------
-    units1 : mapping of hashable to unit-like
-        The units of the existing object which are incompatible with the new units.
-    units2 : mapping of hashable to unit-like
-        The units to convert the object to which are incompatible with the existing
-        units.
-    """
-
-    def __init__(self, units1, units2):
-        if not units1:
-            raise ValueError("no units given")
-        elif units1.keys() != units2.keys():
-            raise ValueError("units1 and units2 must have the same keys")
-
-        self.incompatible_units = {
-            key: (units1[key], units2[key]) for key in units1.keys()
-        }
-
-    def __str__(self):
-        incompatible_units = self.incompatible_units
-
-        message = "Cannot convert some variables:"
-        sep = " " if len(incompatible_units) == 1 else "\n -- "
-
-        message = sep.join(
-            [message]
-            + [
-                f"incompatible units for {key}: {u1.dimensionality} != {u2.dimensionality}"
-                for key, (u1, u2) in incompatible_units.items()
-            ]
-        )
-        return message

--- a/pint_xarray/tests/test_accessors.py
+++ b/pint_xarray/tests/test_accessors.py
@@ -542,7 +542,7 @@ def test_sel(obj, indexers, expected, error):
 def test_loc(obj, indexers, expected, error):
     if error is not None:
         with pytest.raises(error):
-            obj.pint.sel(indexers)
+            obj.pint.loc[indexers]
     else:
         actual = obj.pint.loc[indexers]
         assert_units_equal(actual, expected)

--- a/pint_xarray/tests/test_accessors.py
+++ b/pint_xarray/tests/test_accessors.py
@@ -940,8 +940,20 @@ def test_chunk(obj):
             ),
             {"x": Quantity([1, 3], "s"), "y": Quantity([1], "m")},
             None,
-            DimensionalityError,
+            ValueError,
             id="Dataset-incompatible units",
+        ),
+        pytest.param(
+            xr.Dataset(
+                {
+                    "a": ("x", [10, 20, 30], {"units": unit_registry.Unit("dm")}),
+                    "b": ("y", [60, 120], {"units": unit_registry.Unit("s")}),
+                }
+            ),
+            {"a": Quantity([1, 3], "s"), "b": Quantity([1], "m")},
+            None,
+            ValueError,
+            id="Dataset-incompatible units-invalid dims",
         ),
         pytest.param(
             xr.DataArray(
@@ -996,8 +1008,22 @@ def test_chunk(obj):
             ),
             {"x": Quantity([10, 30], "s"), "y": Quantity([60], "m")},
             None,
-            DimensionalityError,
+            ValueError,
             id="DataArray-incompatible units",
+        ),
+        pytest.param(
+            xr.DataArray(
+                [[0, 1], [2, 3], [4, 5]],
+                dims=("x", "y"),
+                coords={
+                    "x": ("x", [10, 20, 30], {"units": unit_registry.Unit("dm")}),
+                    "y": ("y", [60, 120], {"units": unit_registry.Unit("s")}),
+                },
+            ),
+            {"x": Quantity([10, 30], "s"), "y": Quantity([60], "m")},
+            None,
+            ValueError,
+            id="DataArray-incompatible units-invalid dims",
         ),
     ),
 )

--- a/pint_xarray/tests/test_accessors.py
+++ b/pint_xarray/tests/test_accessors.py
@@ -103,6 +103,14 @@ class TestQuantifyDataArray:
         with pytest.raises(ValueError, match=str(da.name)):
             da.pint.quantify(units="aecjhbav")
 
+    def test_error_on_nonsense_units_attrs(self, example_unitless_da):
+        da = example_unitless_da
+        da.attrs["units"] = "aecjhbav"
+        with pytest.raises(
+            ValueError, match=rf"{da.name}: {da.attrs['units']} \(attribute\)"
+        ):
+            da.pint.quantify()
+
     def test_parse_integer_inverse(self):
         # Regression test for issue #40
         da = xr.DataArray([10], attrs={"units": "m^-1"})
@@ -247,6 +255,14 @@ class TestQuantifyDataSet:
         ds = example_unitless_ds
         with pytest.raises(ValueError):
             ds.pint.quantify(units={"users": "aecjhbav"})
+
+    def test_error_on_nonsense_units_attrs(self, example_unitless_ds):
+        ds = example_unitless_ds
+        ds.users.attrs["units"] = "aecjhbav"
+        with pytest.raises(
+            ValueError, match=rf"'users': {ds.users.attrs['units']} \(attribute\)"
+        ):
+            ds.pint.quantify()
 
     def test_error_indicates_problematic_variable(self, example_unitless_ds):
         ds = example_unitless_ds

--- a/pint_xarray/tests/test_accessors.py
+++ b/pint_xarray/tests/test_accessors.py
@@ -7,7 +7,7 @@ from pint import Unit, UnitRegistry
 from pint.errors import UndefinedUnitError
 
 from .. import accessors, conversion
-from ..errors import DimensionalityError
+from ..errors import DimensionalityError, UnitParsingError
 from .utils import (
     assert_equal,
     assert_identical,
@@ -247,12 +247,12 @@ class TestQuantifyDataSet:
 
     def test_error_on_nonsense_units(self, example_unitless_ds):
         ds = example_unitless_ds
-        with pytest.raises(ValueError):
+        with pytest.raises(UnitParsingError):
             ds.pint.quantify(units={"users": "aecjhbav"})
 
     def test_error_indicates_problematic_variable(self, example_unitless_ds):
         ds = example_unitless_ds
-        with pytest.raises(ValueError, match="users"):
+        with pytest.raises(UnitParsingError, match="'users'"):
             ds.pint.quantify(units={"users": "aecjhbav"})
 
 

--- a/pint_xarray/tests/test_accessors.py
+++ b/pint_xarray/tests/test_accessors.py
@@ -7,7 +7,7 @@ from pint import Unit, UnitRegistry
 from pint.errors import UndefinedUnitError
 
 from .. import accessors, conversion
-from ..errors import DimensionalityError, UnitParsingError
+from ..errors import DimensionalityError
 from .utils import (
     assert_equal,
     assert_identical,
@@ -247,12 +247,12 @@ class TestQuantifyDataSet:
 
     def test_error_on_nonsense_units(self, example_unitless_ds):
         ds = example_unitless_ds
-        with pytest.raises(UnitParsingError):
+        with pytest.raises(ValueError):
             ds.pint.quantify(units={"users": "aecjhbav"})
 
     def test_error_indicates_problematic_variable(self, example_unitless_ds):
         ds = example_unitless_ds
-        with pytest.raises(UnitParsingError, match="'users'"):
+        with pytest.raises(ValueError, match="'users'"):
             ds.pint.quantify(units={"users": "aecjhbav"})
 
 

--- a/pint_xarray/tests/test_conversion.py
+++ b/pint_xarray/tests/test_conversion.py
@@ -275,8 +275,8 @@ class TestXarrayFunctions:
             pytest.param(
                 "none",
                 {"a": Unit("g"), "b": Unit("Pa"), "u": Unit("ms"), "x": Unit("mm")},
-                pint.DimensionalityError,
-                None,
+                ValueError,
+                "(?s)Cannot convert variables:.+'u'",
                 id="none-with units",
             ),
             pytest.param("data", {}, None, None, id="data-no units"),
@@ -290,8 +290,8 @@ class TestXarrayFunctions:
             pytest.param(
                 "data",
                 {"a": Unit("s"), "b": Unit("m")},
-                pint.DimensionalityError,
-                None,
+                ValueError,
+                "(?s)Cannot convert variables:.+'a'",
                 id="data-incompatible units",
             ),
             pytest.param(
@@ -311,8 +311,8 @@ class TestXarrayFunctions:
             pytest.param(
                 "dims",
                 {"x": Unit("ms")},
-                pint.DimensionalityError,
-                None,
+                ValueError,
+                "(?s)Cannot convert variables:.+'x'",
                 id="dims-incompatible units",
             ),
             pytest.param(
@@ -332,8 +332,8 @@ class TestXarrayFunctions:
             pytest.param(
                 "coords",
                 {"u": Unit("mm")},
-                pint.DimensionalityError,
-                None,
+                ValueError,
+                "(?s)Cannot convert variables:.+'u'",
                 id="coords-incompatible units",
             ),
         ),
@@ -544,105 +544,133 @@ class TestXarrayFunctions:
 
 class TestIndexerFunctions:
     @pytest.mark.parametrize(
-        ["indexer", "units", "expected", "error"],
+        ["indexers", "units", "expected", "error", "match"],
         (
-            pytest.param(1, None, 1, None, id="scalar-no units"),
             pytest.param(
-                1,
-                "dimensionless",
-                Quantity(1, "dimensionless"),
+                {"x": 1}, {"x": None}, {"x": 1}, None, None, id="scalar-no units"
+            ),
+            pytest.param(
+                {"x": 1},
+                {"x": "dimensionless"},
+                None,
                 ValueError,
+                "(?s)Cannot convert indexers:.+'x'",
                 id="scalar-dimensionless",
             ),
             pytest.param(
-                Quantity(1, "m"),
-                Unit("dm"),
-                Quantity(10, "dm"),
+                {"x": Quantity(1, "m")},
+                {"x": Unit("dm")},
+                {"x": Quantity(10, "dm")},
+                None,
                 None,
                 id="scalar-units",
             ),
             pytest.param(
-                np.array([1, 2]), None, np.array([1, 2]), None, id="array-no units"
+                {"x": np.array([1, 2])},
+                {"x": None},
+                {"x": np.array([1, 2])},
+                None,
+                None,
+                id="array-no units",
             ),
             pytest.param(
-                Quantity([1, 2], "m"),
-                Unit("dm"),
-                Quantity([10, 20], "dm"),
+                {"x": Quantity([1, 2], "m")},
+                {"x": Unit("dm")},
+                {"x": Quantity([10, 20], "dm")},
+                None,
                 None,
                 id="array-units",
             ),
             pytest.param(
-                Variable("x", [1, 2]),
+                {"x": Variable("x", [1, 2])},
+                {"x": None},
+                {"x": Variable("x", [1, 2])},
                 None,
-                Variable("x", [1, 2]),
                 None,
                 id="Variable-no units",
             ),
             pytest.param(
-                Variable("x", Quantity([1, 2], "m")),
-                Unit("dm"),
-                Variable("x", Quantity([10, 20], "dm")),
+                {"x": Variable("x", Quantity([1, 2], "m"))},
+                {"x": Unit("dm")},
+                {"x": Variable("x", Quantity([10, 20], "dm"))},
+                None,
                 None,
                 id="Variable-units",
             ),
             pytest.param(
-                DataArray([1, 2], dims="x"),
+                {"x": DataArray([1, 2], dims="x")},
+                {"x": None},
+                {"x": DataArray([1, 2], dims="x")},
                 None,
-                DataArray([1, 2], dims="x"),
                 None,
                 id="DataArray-no units",
             ),
             pytest.param(
-                DataArray(Quantity([1, 2], "m"), dims="x"),
-                Unit("dm"),
-                DataArray(Quantity([10, 20], "dm"), dims="x"),
+                {"x": DataArray(Quantity([1, 2], "m"), dims="x")},
+                {"x": Unit("dm")},
+                {"x": DataArray(Quantity([10, 20], "dm"), dims="x")},
+                None,
                 None,
                 id="DataArray-units",
             ),
             pytest.param(
-                slice(None), None, slice(None), None, id="empty slice-no units"
+                {"x": slice(None)},
+                {"x": None},
+                {"x": slice(None)},
+                None,
+                None,
+                id="empty slice-no units",
             ),
             pytest.param(
-                slice(1, None), None, slice(1, None), None, id="slice-no units"
+                {"x": slice(1, None)},
+                {"x": None},
+                {"x": slice(1, None)},
+                None,
+                None,
+                id="slice-no units",
             ),
             pytest.param(
-                slice(Quantity(1, "m"), Quantity(2, "m")),
-                Unit("m"),
-                slice(Quantity(1, "m"), Quantity(2, "m")),
+                {"x": slice(Quantity(1, "m"), Quantity(2, "m"))},
+                {"x": Unit("m")},
+                {"x": slice(Quantity(1, "m"), Quantity(2, "m"))},
+                None,
                 None,
                 id="slice-identical units",
             ),
             pytest.param(
-                slice(Quantity(1, "m"), Quantity(2000, "mm")),
-                Unit("dm"),
-                slice(Quantity(10, "dm"), Quantity(20, "dm")),
+                {"x": slice(Quantity(1, "m"), Quantity(2000, "mm"))},
+                {"x": Unit("dm")},
+                {"x": slice(Quantity(10, "dm"), Quantity(20, "dm"))},
+                None,
                 None,
                 id="slice-compatible units",
             ),
             pytest.param(
-                slice(Quantity(1, "m"), Quantity(2, "m")),
-                Unit("ms"),
+                {"x": slice(Quantity(1, "m"), Quantity(2, "m"))},
+                {"x": Unit("ms")},
                 None,
-                pint.DimensionalityError,
+                ValueError,
+                "(?s)Cannot convert indexers:.+'x'",
                 id="slice-incompatible units",
             ),
             pytest.param(
-                slice(1000, Quantity(2000, "ms")),
-                Unit("s"),
+                {"x": slice(1000, Quantity(2000, "ms"))},
+                {"x": Unit("s")},
                 None,
-                pint.DimensionalityError,
+                ValueError,
+                "(?s)Cannot convert indexers:.+'x'",
                 id="slice-incompatible units-mixed",
             ),
         ),
     )
-    def test_convert_indexer_units(self, indexer, units, expected, error):
+    def test_convert_indexer_units(self, indexers, units, expected, error, match):
         if error is not None:
-            with pytest.raises(error):
-                conversion.convert_indexer_units(indexer, units)
+            with pytest.raises(error, match=match):
+                conversion.convert_indexer_units(indexers, units)
         else:
-            actual = conversion.convert_indexer_units(indexer, units)
-            assert_indexer_equal(actual, expected)
-            assert_indexer_units_equal(actual, expected)
+            actual = conversion.convert_indexer_units(indexers, units)
+            assert_indexer_equal(actual["x"], expected["x"])
+            assert_indexer_units_equal(actual["x"], expected["x"])
 
     @pytest.mark.parametrize(
         ["indexer", "expected"],


### PR DESCRIPTION
Inspired by #43, this collects all errors of a kind and raises a single error message. Not sure if the implementation is really the best way, though (one drawback is that the original traceback will be lost).

This also fixes the error message for operations like `reindex` when trying to specify indexers with incompatible units for data variables (it now displays the `xarray` error instead of complaining about the incompatible units).

<details><summary>examples for the new error messages</summary>

```python
In [1]: import xarray as xr
   ...: import pint_xarray

In [2]: ds = xr.Dataset({"a": ("x", [0, 1]), "b": ("y", [1, 2, 3])})
   ...: ds
Out[2]: 
<xarray.Dataset>
Dimensions:  (x: 2, y: 3)
Dimensions without coordinates: x, y
Data variables:
    a        (x) int64 0 1
    b        (y) int64 1 2 3

In [3]: ds.pint.quantify({"a": "invalid", "b": "invalid2"})
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
<ipython-input-3-273f907e75ca> in <module>
----> 1 ds.pint.quantify({"a": "invalid", "b": "invalid2"})

.../pint_xarray/accessors.py in quantify(self, units, unit_registry, **unit_kwargs)
    972 
    973         if invalid_units:
--> 974             raise ValueError(format_error_message(invalid_units, "parse"))
    975 
    976         return self.ds.pipe(conversion.strip_unit_attributes).pipe(

ValueError: Cannot parse units:
 -- invalid units for variable 'b': invalid2 (parameter) (reason: 'invalid2' is not defined in the unit registry)
 -- invalid units for variable 'a': invalid (parameter) (reason: 'invalid' is not defined in the unit registry)

In [4]: quantified = ds.pint.quantify({"a": "m", "b": "s"})
   ...: quantified
Out[4]: 
<xarray.Dataset>
Dimensions:  (x: 2, y: 3)
Dimensions without coordinates: x, y
Data variables:
    a        (x) int64 [m] 0 1
    b        (y) int64 [s] 1 2 3

In [5]: quantified.pint.to({"a": "ms", "b": "mm"})
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
<ipython-input-5-254b9671693a> in <module>
----> 1 quantified.pint.to({"a": "ms", "b": "mm"})

.../pint_xarray/accessors.py in to(self, units, **unit_kwargs)
   1150         units = either_dict_or_kwargs(units, unit_kwargs, "to")
   1151 
-> 1152         return conversion.convert_units(self.ds, units)
   1153 
   1154     def chunk(self, chunks, name_prefix="xarray-", token=None, lock=False):

.../pint_xarray/conversion.py in convert_units(obj, units)
    213 
    214         if failed:
--> 215             raise ValueError(format_error_message(failed, "convert"))
    216 
    217         coords = {

ValueError: Cannot convert variables:
 -- incompatible units for variable 'a': Cannot convert from 'meter' ([length]) to 'millisecond' ([time])
 -- incompatible units for variable 'b': Cannot convert from 'second' ([time]) to 'millimeter' ([length])
```

</details>

cc @TomNicholas

- [x] Tests added
- [x] Passes `pre-commit run --all-files`
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
