### PR TITLE
fix upstream-dev

### DIFF
--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -39,7 +39,7 @@ What's new
   By `Justus Magin <https://github.com/keewis>`_.
 - implement :py:meth:`Dataset.pint.interp`, :py:meth:`Dataset.pint.interp_like`,
   :py:meth:`DataArray.pint.interp` and :py:meth:`DataArray.pint.interp_like`
-     (:pull:`72`, :pull:`76`, :pull:`97`).
+  (:pull:`72`, :pull:`76`, :pull:`97`).
   By `Justus Magin <https://github.com/keewis>`_.
 - implement :py:meth:`Dataset.pint.ffill`, :py:meth:`Dataset.pint.bfill`,
   :py:meth:`DataArray.pint.ffill` and :py:meth:`DataArray.pint.bfill` (:pull:`78`).

--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -38,7 +38,8 @@ What's new
   :py:meth:`DataArray.pint.reindex` and :py:meth:`DataArray.pint.reindex_like` (:pull:`69`).
   By `Justus Magin <https://github.com/keewis>`_.
 - implement :py:meth:`Dataset.pint.interp`, :py:meth:`Dataset.pint.interp_like`,
-  :py:meth:`DataArray.pint.interp` and :py:meth:`DataArray.pint.interp_like` (:pull:`72`, :pull:`76`).
+  :py:meth:`DataArray.pint.interp` and :py:meth:`DataArray.pint.interp_like`
+     (:pull:`72`, :pull:`76`, :pull:`97`).
   By `Justus Magin <https://github.com/keewis>`_.
 - implement :py:meth:`Dataset.pint.ffill`, :py:meth:`Dataset.pint.bfill`,
   :py:meth:`DataArray.pint.ffill` and :py:meth:`DataArray.pint.bfill` (:pull:`78`).

--- a/pint_xarray/conversion.py
+++ b/pint_xarray/conversion.py
@@ -173,12 +173,16 @@ def convert_units_variable(variable, units):
             # don't try to convert MultiIndexes
             return variable
 
-        quantity = array_attach_units(
-            variable.data, variable.attrs.get(unit_attribute_name)
-        )
-        converted = array_convert_units(quantity, units)
-        new_obj = variable.copy(data=array_strip_units(converted))
-        new_obj.attrs[unit_attribute_name] = array_extract_units(converted)
+        if units is not None:
+            quantity = array_attach_units(
+                variable.data, variable.attrs.get(unit_attribute_name)
+            )
+            converted = array_convert_units(quantity, units)
+            new_obj = variable.copy(data=array_strip_units(converted))
+
+            new_obj.attrs[unit_attribute_name] = units
+        else:
+            new_obj = variable.copy()
     elif isinstance(variable, Variable):
         converted = array_convert_units(variable.data, units)
         new_obj = variable.copy(data=converted)

--- a/pint_xarray/conversion.py
+++ b/pint_xarray/conversion.py
@@ -182,7 +182,7 @@ def convert_units_variable(variable, units):
 
             new_obj.attrs[unit_attribute_name] = units
         else:
-            new_obj = variable.copy()
+            new_obj = variable
     elif isinstance(variable, Variable):
         converted = array_convert_units(variable.data, units)
         new_obj = variable.copy(data=converted)

--- a/pint_xarray/conversion.py
+++ b/pint_xarray/conversion.py
@@ -180,7 +180,7 @@ def convert_units_variable(variable, units):
             converted = array_convert_units(quantity, units)
             new_obj = variable.copy(data=array_strip_units(converted))
 
-            new_obj.attrs[unit_attribute_name] = units
+            new_obj.attrs[unit_attribute_name] = array_extract_units(converted)
         else:
             new_obj = variable
     elif isinstance(variable, Variable):

--- a/pint_xarray/testing.py
+++ b/pint_xarray/testing.py
@@ -1,4 +1,4 @@
-from . import conversion
+from . import conversion, formatting
 
 
 def assert_units_equal(a, b):
@@ -16,7 +16,14 @@ def assert_units_equal(a, b):
 
     __tracebackhide__ = True
 
-    assert conversion.extract_units(a) == conversion.extract_units(b)
-    assert conversion.extract_unit_attributes(a) == conversion.extract_unit_attributes(
-        b
+    units_a = conversion.extract_units(a)
+    units_b = conversion.extract_units(b)
+    assert units_a == units_b, formatting._diff_mapping_repr(
+        units_a, units_b, "Units", formatting.summarize_attr
+    )
+
+    unit_attrs_a = conversion.extract_unit_attributes(a)
+    unit_attrs_b = conversion.extract_unit_attributes(b)
+    assert unit_attrs_a == unit_attrs_b, formatting._diff_mapping_repr(
+        unit_attrs_a, unit_attrs_b, "Unit attrs", formatting.summarize_attr
     )

--- a/pint_xarray/tests/utils.py
+++ b/pint_xarray/tests/utils.py
@@ -10,10 +10,10 @@ from xarray.testing import assert_equal, assert_identical  # noqa: F401
 from ..conversion import (
     array_strip_units,
     extract_indexer_units,
-    extract_units,
     strip_units,
     strip_units_variable,
 )
+from ..testing import assert_units_equal  # noqa: F401
 
 
 def importorskip(name):
@@ -104,8 +104,3 @@ def assert_indexer_units_equal(a, b):
     units_b = extract_indexer_units(b)
 
     assert units_a == units_b, f"different units: {units_a!r} ←→ {units_b!r}"
-
-
-def assert_units_equal(a, b):
-    __tracebackhide__ = True
-    assert extract_units(a) == extract_units(b)


### PR DESCRIPTION
The change in pydata/xarray#5031 exposed two bugs: the upstream-dev CI report job was broken (fixed by #95) and dimensions would be converted even if the units are `None` (*and* the units attr is set to `None`)

- [x] Closes #96
- [x] Passes `pre-commit run --all-files`
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
