### PR TITLE
support for "no unit" values

### DIFF
--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -5,7 +5,9 @@ What's new
 
 0.3 (*unreleased*)
 ------------------
-
+- allow special "no unit" values in :py:meth:`Dataset.pint.quantify` and
+  :py:meth:`DataArray.pint.quantify` (:pull:`125`)
+  By `Justus Magin <https://github.com/keewis>`_.
 
 0.2 (May 10 2021)
 -----------------

--- a/pint_xarray/accessors.py
+++ b/pint_xarray/accessors.py
@@ -325,7 +325,7 @@ class PintDataArrayAccessor:
 
         registry = get_registry(unit_registry, units, conversion.extract_units(self.da))
 
-        unit_attrs = conversion.extract_unit_attributes(self.da, fill_value=_default)
+        unit_attrs = conversion.extract_unit_attributes(self.da)
 
         possible_new_units = zip_mappings(units, unit_attrs, fill_value=_default)
         new_units = {}
@@ -963,7 +963,7 @@ class PintDatasetAccessor:
         units = either_dict_or_kwargs(units, unit_kwargs, "quantify")
         registry = get_registry(unit_registry, units, conversion.extract_units(self.ds))
 
-        unit_attrs = conversion.extract_unit_attributes(self.ds, fill_value=_default)
+        unit_attrs = conversion.extract_unit_attributes(self.ds)
 
         possible_new_units = zip_mappings(units, unit_attrs, fill_value=_default)
         new_units = {}

--- a/pint_xarray/accessors.py
+++ b/pint_xarray/accessors.py
@@ -140,9 +140,9 @@ def _decide_units(units, registry, unit_attribute):
     elif units in no_unit_values or isinstance(units, Unit):
         # TODO what happens if they pass in a Unit from a different registry
         return units
-    elif unit_attribute in no_unit_values:
-        return unit_attribute
     elif units is _default:
+        if unit_attribute in no_unit_values:
+            return unit_attribute
         units = registry.parse_units(unit_attribute)
     else:
         units = registry.parse_units(units)

--- a/pint_xarray/accessors.py
+++ b/pint_xarray/accessors.py
@@ -8,6 +8,7 @@ from xarray import register_dataarray_accessor, register_dataset_accessor
 from xarray.core.dtypes import NA
 
 from . import conversion
+from .conversion import no_unit_values
 from .errors import format_error_message
 
 _default = object()
@@ -136,14 +137,16 @@ def _decide_units(units, registry, unit_attribute):
     if units is _default and unit_attribute is _default:
         # or warn and return None?
         raise ValueError("no units given")
-    elif units is _default:
-        # TODO option to read and decode units according to CF conventions (see MetPy)?
-        units = registry.parse_units(unit_attribute)
-    elif isinstance(units, Unit):
+    elif units in no_unit_values or isinstance(units, Unit):
         # TODO do we have to check what happens if someone passes a Unit instance
         # without creating a unit registry?
         # TODO and what happens if they pass in a Unit from a different registry
-        pass
+        return units
+    elif unit_attribute in no_unit_values:
+        return unit_attribute
+    elif units is _default:
+        # TODO option to read and decode units according to CF conventions (see MetPy)?
+        units = registry.parse_units(unit_attribute)
     else:
         units = registry.parse_units(units)
     return units

--- a/pint_xarray/accessors.py
+++ b/pint_xarray/accessors.py
@@ -138,14 +138,11 @@ def _decide_units(units, registry, unit_attribute):
         # or warn and return None?
         raise ValueError("no units given")
     elif units in no_unit_values or isinstance(units, Unit):
-        # TODO do we have to check what happens if someone passes a Unit instance
-        # without creating a unit registry?
-        # TODO and what happens if they pass in a Unit from a different registry
+        # TODO what happens if they pass in a Unit from a different registry
         return units
     elif unit_attribute in no_unit_values:
         return unit_attribute
     elif units is _default:
-        # TODO option to read and decode units according to CF conventions (see MetPy)?
         units = registry.parse_units(unit_attribute)
     else:
         units = registry.parse_units(units)

--- a/pint_xarray/accessors.py
+++ b/pint_xarray/accessors.py
@@ -289,7 +289,7 @@ class PintDataArrayAccessor:
 
         Notes
         -----
-        ``"1"``, ``"none"``, and ``None`` can be used to mark variables that should not
+        ``"none"`` and ``None`` can be used to mark variables that should not
         be quantified.
 
         Examples
@@ -931,7 +931,7 @@ class PintDatasetAccessor:
 
         Notes
         -----
-        ``"1"``, ``"none"``, and ``None`` can be used to mark variables
+        ``"none"`` and ``None`` can be used to mark variables
         that should not be quantified.
 
         Examples

--- a/pint_xarray/accessors.py
+++ b/pint_xarray/accessors.py
@@ -271,7 +271,7 @@ class PintDataArrayAccessor:
             pint.Unit, will be used as the DataArray's units. If a
             dict-like, it should map a variable name to the desired
             unit (use the DataArray's name to refer to its data). If
-            not provided, will try to read them from
+            not provided, ``quantify`` will try to read them from
             ``DataArray.attrs['units']`` using pint's parser. The
             ``"units"`` attribute will be removed from all variables
             except from dimension coordinates.
@@ -907,10 +907,10 @@ class PintDatasetAccessor:
         units : mapping of hashable to unit-like, optional
             Physical units to use for particular DataArrays in this
             Dataset. It should map variable names to units (unit names
-            or ``pint.Unit`` objects). If not provided, will try to
-            read them from ``Dataset[var].attrs['units']`` using
-            pint's parser. The ``"units"`` attribute will be removed
-            from all variables except from dimension coordinates.
+            or ``pint.Unit`` objects). If not provided, ``quantify``
+            will try to read them from ``Dataset[var].attrs['units']``
+            using pint's parser. The ``"units"`` attribute will be
+            removed from all variables except from dimension coordinates.
         unit_registry : pint.UnitRegistry, optional
             Unit registry to be used for the units attached to each
             DataArray in this Dataset. If not given then a default

--- a/pint_xarray/accessors.py
+++ b/pint_xarray/accessors.py
@@ -306,6 +306,7 @@ class PintDataArrayAccessor:
           * wavelength  (wavelength) float64 0.0001 0.0002 0.0004 0.0006 0.001 0.002
 
         Don't quantify the data:
+
         >>> da = xr.DataArray(
         ...     data=[0.4, 0.9],
         ...     dims=["wavelength"],
@@ -972,6 +973,7 @@ class PintDatasetAccessor:
             b        (x) int64 [dm] 5 -2 1
 
         Don't quantify specific variables:
+
         >>> ds.pint.quantify({"a": None})
         <xarray.Dataset>
         Dimensions:  (x: 3)

--- a/pint_xarray/accessors.py
+++ b/pint_xarray/accessors.py
@@ -287,6 +287,11 @@ class PintDataArrayAccessor:
             DataArray whose wrapped array data will now be a Quantity
             array with the specified units.
 
+        Notes
+        -----
+        ``"1"``, ``"none"``, and ``None`` can be used to mark variables that should not
+        be quantified.
+
         Examples
         --------
         >>> da = xr.DataArray(
@@ -923,6 +928,11 @@ class PintDatasetAccessor:
         quantified : Dataset
             Dataset whose variables will now contain Quantity arrays
             with units.
+
+        Notes
+        -----
+        ``"1"``, ``"none"``, and ``None`` can be used to mark variables
+        that should not be quantified.
 
         Examples
         --------

--- a/pint_xarray/accessors.py
+++ b/pint_xarray/accessors.py
@@ -304,6 +304,17 @@ class PintDataArrayAccessor:
         <Quantity([0.4 0.9 1.7 4.8 3.2 9.1], 'hertz')>
         Coordinates:
           * wavelength  (wavelength) float64 0.0001 0.0002 0.0004 0.0006 0.001 0.002
+
+        Don't quantify the data:
+        >>> da = xr.DataArray(
+        ...     data=[0.4, 0.9],
+        ...     dims=["wavelength"],
+        ...     attrs={"units": "Hz"},
+        ... )
+        >>> da.pint.quantify(units=None)
+        <xarray.DataArray (wavelength: 2)>
+        array([0.4, 0.9])
+        Dimensions without coordinates: wavelength
         """
 
         if isinstance(self.da.data, Quantity):
@@ -959,6 +970,17 @@ class PintDatasetAccessor:
         Data variables:
             a        (x) int64 [m] 0 3 2
             b        (x) int64 [dm] 5 -2 1
+
+        Don't quantify specific variables:
+        >>> ds.pint.quantify({"a": None})
+        <xarray.Dataset>
+        Dimensions:  (x: 3)
+        Coordinates:
+          * x        (x) int64 0 1 2
+            u        (x) int64 [s] -1 0 1
+        Data variables:
+            a        (x) int64 0 3 2
+            b        (x) int64 5 -2 1
         """
         units = either_dict_or_kwargs(units, unit_kwargs, "quantify")
         registry = get_registry(unit_registry, units, conversion.extract_units(self.ds))

--- a/pint_xarray/conversion.py
+++ b/pint_xarray/conversion.py
@@ -25,7 +25,7 @@ def array_attach_units(data, unit):
     quantity : pint.Quantity
     """
 
-    if unit in no_unit_values:
+    if unit is None:
         return data
 
     if not isinstance(unit, pint.Unit):
@@ -258,7 +258,7 @@ def extract_units(obj):
     return units
 
 
-def extract_unit_attributes(obj, attr="units"):
+def extract_unit_attributes(obj, attr="units", fill_value=None):
     if isinstance(obj, DataArray):
         original_name = obj.name
         name = obj.name if obj.name is not None else "<this-array>"
@@ -268,7 +268,9 @@ def extract_unit_attributes(obj, attr="units"):
         units = extract_unit_attributes(ds)
         units[original_name] = units.pop(name)
     elif isinstance(obj, Dataset):
-        units = {name: var.attrs.get(attr, None) for name, var in obj.variables.items()}
+        units = {
+            name: var.attrs.get(attr, fill_value) for name, var in obj.variables.items()
+        }
     else:
         raise ValueError(
             f"cannot retrieve unit attributes from unknown type: {type(obj)}"

--- a/pint_xarray/conversion.py
+++ b/pint_xarray/conversion.py
@@ -24,8 +24,9 @@ def array_attach_units(data, unit):
     -------
     quantity : pint.Quantity
     """
-
-    if unit is None:
+    # type-check because 'ureg.dimensionless in no_unit_values'
+    # evaluates to True for some reason
+    if not isinstance(unit, pint.Unit) and unit in no_unit_values:
         return data
 
     if not isinstance(unit, pint.Unit):

--- a/pint_xarray/conversion.py
+++ b/pint_xarray/conversion.py
@@ -24,8 +24,7 @@ def array_attach_units(data, unit):
     -------
     quantity : pint.Quantity
     """
-    # type-check because 'ureg.dimensionless in no_unit_values'
-    # evaluates to True for some reason
+    # type-check because 'ureg.dimensionless == "1"' is True
     if not isinstance(unit, pint.Unit) and unit in no_unit_values:
         return data
 

--- a/pint_xarray/conversion.py
+++ b/pint_xarray/conversion.py
@@ -5,7 +5,7 @@ from xarray import DataArray, Dataset, IndexVariable, Variable
 
 from .errors import format_error_message
 
-no_unit_values = ("1", "none", None)
+no_unit_values = ("none", None)
 unit_attribute_name = "units"
 slice_attributes = ("start", "stop", "step")
 
@@ -24,8 +24,7 @@ def array_attach_units(data, unit):
     -------
     quantity : pint.Quantity
     """
-    # type-check because 'ureg.dimensionless == "1"' is True
-    if not isinstance(unit, pint.Unit) and unit in no_unit_values:
+    if unit in no_unit_values:
         return data
 
     if not isinstance(unit, pint.Unit):

--- a/pint_xarray/conversion.py
+++ b/pint_xarray/conversion.py
@@ -5,7 +5,7 @@ from xarray import DataArray, Dataset, IndexVariable, Variable
 
 from .errors import format_error_message
 
-no_unit_values = ("1", "none")
+no_unit_values = ("1", "none", None)
 unit_attribute_name = "units"
 slice_attributes = ("start", "stop", "step")
 

--- a/pint_xarray/conversion.py
+++ b/pint_xarray/conversion.py
@@ -5,7 +5,7 @@ from xarray import DataArray, Dataset, IndexVariable, Variable
 
 from .errors import format_error_message
 
-no_unit_values = (1, "1", None, "none")
+no_unit_values = ("1", "none")
 unit_attribute_name = "units"
 slice_attributes = ("start", "stop", "step")
 

--- a/pint_xarray/conversion.py
+++ b/pint_xarray/conversion.py
@@ -258,7 +258,7 @@ def extract_units(obj):
     return units
 
 
-def extract_unit_attributes(obj, attr="units", fill_value=None):
+def extract_unit_attributes(obj, attr="units"):
     if isinstance(obj, DataArray):
         original_name = obj.name
         name = obj.name if obj.name is not None else "<this-array>"
@@ -268,9 +268,7 @@ def extract_unit_attributes(obj, attr="units", fill_value=None):
         units = extract_unit_attributes(ds)
         units[original_name] = units.pop(name)
     elif isinstance(obj, Dataset):
-        units = {
-            name: var.attrs.get(attr, fill_value) for name, var in obj.variables.items()
-        }
+        units = {name: var.attrs.get(attr, None) for name, var in obj.variables.items()}
     else:
         raise ValueError(
             f"cannot retrieve unit attributes from unknown type: {type(obj)}"

--- a/pint_xarray/conversion.py
+++ b/pint_xarray/conversion.py
@@ -5,6 +5,7 @@ from xarray import DataArray, Dataset, IndexVariable, Variable
 
 from .errors import format_error_message
 
+no_unit_values = (1, "1", None, "none")
 unit_attribute_name = "units"
 slice_attributes = ("start", "stop", "step")
 
@@ -24,7 +25,7 @@ def array_attach_units(data, unit):
     quantity : pint.Quantity
     """
 
-    if unit is None:
+    if unit in no_unit_values:
         return data
 
     if not isinstance(unit, pint.Unit):

--- a/pint_xarray/tests/test_accessors.py
+++ b/pint_xarray/tests/test_accessors.py
@@ -96,8 +96,9 @@ class TestQuantifyDataArray:
     @pytest.mark.parametrize("no_unit_value", conversion.no_unit_values)
     def test_override_units(self, example_unitless_da, no_unit_value):
         orig = example_unitless_da
-        result = orig.pint.quantify(no_unit_value)
+        result = orig.pint.quantify(no_unit_value, u=no_unit_value)
         assert getattr(result.data, "units", "not a quantity") == "not a quantity"
+        assert getattr(result["u"].data, "units", "not a quantity") == "not a quantity"
 
     def test_error_when_already_units(self, example_quantity_da):
         da = example_quantity_da

--- a/pint_xarray/tests/test_accessors.py
+++ b/pint_xarray/tests/test_accessors.py
@@ -104,8 +104,11 @@ class TestQuantifyDataArray:
     def test_override_units(self, example_unitless_da, no_unit_value):
         orig = example_unitless_da
         result = orig.pint.quantify(no_unit_value, u=no_unit_value)
-        assert getattr(result.data, "units", "not a quantity") == "not a quantity"
-        assert getattr(result["u"].data, "units", "not a quantity") == "not a quantity"
+
+        with pytest.raises(AttributeError):
+            result.data.units
+        with pytest.raises(AttributeError):
+            result["u"].data.units
 
     def test_error_when_already_units(self, example_quantity_da):
         da = example_quantity_da

--- a/pint_xarray/tests/test_accessors.py
+++ b/pint_xarray/tests/test_accessors.py
@@ -86,6 +86,13 @@ class TestQuantifyDataArray:
         remaining_attrs = conversion.extract_unit_attributes(result)
         assert {k: v for k, v in remaining_attrs.items() if v is not None} == {}
 
+    def test_attach_units_from_str_attr_no_unit(self, example_unitless_da):
+        orig = example_unitless_da
+        orig.attrs["units"] = "none"
+        result = orig.pint.quantify("m")
+        assert_array_equal(result.data.magnitude, orig.data)
+        assert str(result.data.units) == "meter"
+
     def test_attach_units_given_unit_objs(self, example_unitless_da):
         orig = example_unitless_da
         ureg = UnitRegistry(force_ndarray=True)
@@ -253,6 +260,13 @@ class TestQuantifyDataSet:
         result = orig.pint.quantify({"users": dimensionless})
         assert_array_equal(result["users"].data.magnitude, orig["users"].data)
         assert str(result["users"].data.units) == "dimensionless"
+
+    def test_attach_units_from_str_attr_no_unit(self, example_unitless_ds):
+        orig = example_unitless_ds
+        orig["users"].attrs["units"] = "none"
+        result = orig.pint.quantify({"users": "m"})
+        assert_array_equal(result["users"].data.magnitude, orig.data)
+        assert str(result["users"].data.units) == "meter"
 
     @pytest.mark.parametrize("no_unit_value", conversion.no_unit_values)
     def test_override_units(self, example_unitless_ds, no_unit_value):

--- a/pint_xarray/tests/test_accessors.py
+++ b/pint_xarray/tests/test_accessors.py
@@ -93,6 +93,12 @@ class TestQuantifyDataArray:
         assert_array_equal(result.data.magnitude, orig.data)
         assert result.data.units == ureg.Unit("m")
 
+    @pytest.mark.parametrize("no_unit_value", conversion.no_unit_values)
+    def test_override_units(self, example_unitless_da, no_unit_value):
+        orig = example_unitless_da
+        result = orig.pint.quantify(no_unit_value)
+        assert getattr(result.data, "units", "not a quantity") == "not a quantity"
+
     def test_error_when_already_units(self, example_quantity_da):
         da = example_quantity_da
         with raises_regex(ValueError, "already has units"):
@@ -246,6 +252,14 @@ class TestQuantifyDataSet:
         result = orig.pint.quantify({"users": dimensionless})
         assert_array_equal(result["users"].data.magnitude, orig["users"].data)
         assert str(result["users"].data.units) == "dimensionless"
+
+    @pytest.mark.parametrize("no_unit_value", conversion.no_unit_values)
+    def test_override_units(self, example_unitless_ds, no_unit_value):
+        orig = example_unitless_ds
+        result = orig.pint.quantify({"users": no_unit_value})
+        assert (
+            getattr(result["users"].data, "units", "not a quantity") == "not a quantity"
+        )
 
     def test_error_when_already_units(self, example_quantity_ds):
         with raises_regex(ValueError, "already has units"):

--- a/pint_xarray/tests/test_accessors.py
+++ b/pint_xarray/tests/test_accessors.py
@@ -65,10 +65,10 @@ def example_quantity_da():
 class TestQuantifyDataArray:
     def test_attach_units_from_str(self, example_unitless_da):
         orig = example_unitless_da
-        result = orig.pint.quantify("m")
+        result = orig.pint.quantify("s")
         assert_array_equal(result.data.magnitude, orig.data)
         # TODO better comparisons for when you can't access the unit_registry?
-        assert str(result.data.units) == "meter"
+        assert str(result.data.units) == "second"
 
     def test_attach_units_given_registry(self, example_unitless_da):
         orig = example_unitless_da

--- a/pint_xarray/tests/test_accessors.py
+++ b/pint_xarray/tests/test_accessors.py
@@ -265,7 +265,7 @@ class TestQuantifyDataSet:
         orig = example_unitless_ds
         orig["users"].attrs["units"] = "none"
         result = orig.pint.quantify({"users": "m"})
-        assert_array_equal(result["users"].data.magnitude, orig.data)
+        assert_array_equal(result["users"].data.magnitude, orig["users"].data)
         assert str(result["users"].data.units) == "meter"
 
     @pytest.mark.parametrize("no_unit_value", conversion.no_unit_values)


### PR DESCRIPTION
This exposes the internal use of `None` as a "no unit" value and adds the new values requested in #118 (I skipped the integer `1` for now but it should be a single line change to add it).

cc @dcherian, @jbusecke

- [x] Closes #118
- [x] Tests added
- [x] Passes `pre-commit run --all-files`
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [x] ~New functions/methods are listed in `api.rst`~
