### PR TITLE
warn about `.quantify` setting the units of dimension coordinates as attributes

### DIFF
--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -8,6 +8,9 @@ What's new
 - allow special "no unit" values in :py:meth:`Dataset.pint.quantify` and
   :py:meth:`DataArray.pint.quantify` (:pull:`125`)
   By `Justus Magin <https://github.com/keewis>`_.
+- convert the note about dimension coordinates saving their units in the attributes a
+  warning (:pull:``, :issue:``)
+  By `Justus Magin <https://github.com/keewis>`_.
 
 0.2 (May 10 2021)
 -----------------

--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -9,7 +9,7 @@ What's new
   :py:meth:`DataArray.pint.quantify` (:pull:`125`)
   By `Justus Magin <https://github.com/keewis>`_.
 - convert the note about dimension coordinates saving their units in the attributes a
-  warning (:pull:``, :issue:``)
+  warning (:issue:`124`, :pull:`126`)
   By `Justus Magin <https://github.com/keewis>`_.
 
 0.2 (May 10 2021)

--- a/pint_xarray/accessors.py
+++ b/pint_xarray/accessors.py
@@ -260,6 +260,8 @@ class PintDataArrayAccessor:
             the data into memory. To avoid that, consider converting
             to ``dask`` first (e.g. using ``chunk``).
 
+        .. warning::
+
             As units in dimension coordinates are not supported until
             ``xarray`` changes the way it implements indexes, these
             units will be set as attributes.
@@ -914,6 +916,8 @@ class PintDatasetAccessor:
             Be aware that unless you're using ``dask`` this will load
             the data into memory. To avoid that, consider converting
             to ``dask`` first (e.g. using ``chunk``).
+
+        .. warning::
 
             As units in dimension coordinates are not supported until
             ``xarray`` changes the way it implements indexes, these


### PR DESCRIPTION
Hopefully this makes that gotcha more visible.

- [x] Closes #124
- [x] ~Tests added~
- [x] Passes `pre-commit run --all-files`
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [x] ~New functions/methods are listed in `api.rst`~
