### PR TITLE
improve the documentation of the `format` parameter of `.pint.dequantify`

### DIFF
--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -12,7 +12,7 @@ What's new
   warning (:issue:`124`, :pull:`126`)
   By `Justus Magin <https://github.com/keewis>`_.
 - improve the documentation on the ``format`` parameter of :py:meth:`Dataset.pint.dequantify`
-  and :py:meth:`DataArray.pint.dequantify` (:issue:`121`, :pull:``)
+  and :py:meth:`DataArray.pint.dequantify` (:issue:`121`, :pull:`127`)
   By `Justus Magin <https://github.com/keewis>`_.
 
 0.2 (May 10 2021)

--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -11,6 +11,9 @@ What's new
 - convert the note about dimension coordinates saving their units in the attributes a
   warning (:issue:`124`, :pull:`126`)
   By `Justus Magin <https://github.com/keewis>`_.
+- improve the documentation on the ``format`` parameter of :py:meth:`Dataset.pint.dequantify`
+  and :py:meth:`DataArray.pint.dequantify` (:issue:`121`, :pull:``)
+  By `Justus Magin <https://github.com/keewis>`_.
 
 0.2 (May 10 2021)
 -----------------

--- a/pint_xarray/accessors.py
+++ b/pint_xarray/accessors.py
@@ -375,13 +375,39 @@ class PintDataArrayAccessor:
         Parameters
         ----------
         format : str, optional
-            The format used for the string representations.
+            The format specification (as accepted by pint) used for the string
+            representations.
 
         Returns
         -------
         dequantified : DataArray
             DataArray whose array data is unitless, and of the type
             that was previously wrapped by `pint.Quantity`.
+
+        See Also
+        --------
+        https://pint.readthedocs.io/en/stable/tutorial.html#string-formatting
+
+        Examples
+        --------
+        >>> da = xr.DataArray([0, 1], dims="x")
+        >>> q = da.pint.quantify("m")
+        >>> q
+        <xarray.DataArray (x: 2)>
+        <Quantity([0 1], 'meter')>
+        Dimensions without coordinates: x
+        >>> q.pint.dequantify(format="P")
+        <xarray.DataArray (x: 2)>
+        array([0, 1])
+        Dimensions without coordinates: x
+        Attributes:
+            units:    meter
+        >>> q.pint.dequantify(format="~P")
+        <xarray.DataArray (x: 2)>
+        array([0, 1])
+        Dimensions without coordinates: x
+        Attributes:
+            units:    m
         """
         units = conversion.extract_unit_attributes(self.da)
         units.update(conversion.extract_units(self.da))
@@ -1027,13 +1053,44 @@ class PintDatasetAccessor:
         Parameters
         ----------
         format : str, optional
-            The format used for the string representations.
+            The format specification (as accepted by pint) used for the string
+            representations.
 
         Returns
         -------
         dequantified : Dataset
             Dataset whose data variables are unitless, and of the type
             that was previously wrapped by ``pint.Quantity``.
+
+        See Also
+        --------
+        https://pint.readthedocs.io/en/stable/tutorial.html#string-formatting
+
+        Examples
+        --------
+        >>> ds = xr.Dataset({"a": ("x", [0, 1]), "b": ("y", [2, 3, 4])})
+        >>> q = ds.pint.quantify({"a": "m", "b": "s"})
+        >>> q
+        <xarray.Dataset>
+        Dimensions:  (x: 2, y: 3)
+        Dimensions without coordinates: x, y
+        Data variables:
+            a        (x) int64 [m] 0 1
+            b        (y) int64 [s] 2 3 4
+        >>> q.pint.dequantify(format="P")
+        <xarray.Dataset>
+        Dimensions:  (x: 2, y: 3)
+        Dimensions without coordinates: x, y
+        Data variables:
+            a        (x) int64 0 1
+            b        (y) int64 2 3 4
+        >>> q.pint.dequantify(format="~P")
+        <xarray.Dataset>
+        Dimensions:  (x: 2, y: 3)
+        Dimensions without coordinates: x, y
+        Data variables:
+            a        (x) int64 0 1
+            b        (y) int64 2 3 4
         """
         units = conversion.extract_unit_attributes(self.ds)
         units.update(conversion.extract_units(self.ds))

--- a/pint_xarray/accessors.py
+++ b/pint_xarray/accessors.py
@@ -1077,20 +1077,34 @@ class PintDatasetAccessor:
         Data variables:
             a        (x) int64 [m] 0 1
             b        (y) int64 [s] 2 3 4
-        >>> q.pint.dequantify(format="P")
-        <xarray.Dataset>
-        Dimensions:  (x: 2, y: 3)
-        Dimensions without coordinates: x, y
-        Data variables:
-            a        (x) int64 0 1
-            b        (y) int64 2 3 4
-        >>> q.pint.dequantify(format="~P")
-        <xarray.Dataset>
-        Dimensions:  (x: 2, y: 3)
-        Dimensions without coordinates: x, y
-        Data variables:
-            a        (x) int64 0 1
-            b        (y) int64 2 3 4
+
+        >>> d = q.pint.dequantify(format="P")
+        >>> d.a
+        <xarray.DataArray 'a' (x: 2)>
+        array([0, 1])
+        Dimensions without coordinates: x
+        Attributes:
+            units:    meter
+        >>> d.b
+        <xarray.DataArray 'b' (y: 3)>
+        array([2, 3, 4])
+        Dimensions without coordinates: y
+        Attributes:
+            units:    second
+
+        >>> d = q.pint.dequantify(format="~P")
+        >>> d.a
+        <xarray.DataArray 'a' (x: 2)>
+        array([0, 1])
+        Dimensions without coordinates: x
+        Attributes:
+            units:    m
+        >>> d.b
+        <xarray.DataArray 'b' (y: 3)>
+        array([2, 3, 4])
+        Dimensions without coordinates: y
+        Attributes:
+            units:    s
         """
         units = conversion.extract_unit_attributes(self.ds)
         units.update(conversion.extract_units(self.ds))


### PR DESCRIPTION
Not sure what to do about the examples in `Dataset.pint.dequantify`, though: the attributes on the data variables are not visible

- [x] Closes #121
- [x] Passes `pre-commit run --all-files`
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
