### PR TITLE
update the CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.7, 3.8, 3.9, 3.10]
+        python-version: [3.7, 3.8, 3.9]
 
     steps:
     - name: cancel previous runs


### PR DESCRIPTION
I just noticed we were using `python=3.8` for the upstream-dev tests. I'll also use this to check whether testing on `python=3.10` is already possible (obviously, `xarray` doesn't do this, yet).

Edit: `python=3.10` is not supported by `setup-python`, yet, it assumes single digit versions and tries to install `python=3.1`

- [x] Passes `pre-commit run --all-files`
