### PR TITLE
implement the `PintMetaIndex`

### DIFF
--- a/pint_xarray/index.py
+++ b/pint_xarray/index.py
@@ -1,0 +1,30 @@
+from xarray.core.indexes import Index
+
+from . import conversion
+
+
+class PintMetaIndex(Index):
+    # TODO: inherit from MetaIndex once that exists
+    def __init__(self, *, index, units):
+        """create a unit-aware MetaIndex
+
+        Parameters
+        ----------
+        index : xarray.Index
+            The wrapped index object.
+        units : mapping of hashable to unit-like
+            The units of the indexed coordinates
+        """
+        self.index = index
+        self.units = units
+
+    # don't need `from_variables`: we're always *wrapping* an existing index
+
+    def sel(self, labels):
+        converted_labels = conversion.convert_indexer_units(labels, self.units)
+        stripped_labels = {
+            name: conversion.strip_indexer_units(indexer)
+            for name, indexer in converted_labels.items()
+        }
+
+        return self.index.sel(stripped_labels)


### PR DESCRIPTION
As mentioned in #162, it is possible to get the indexing functions to
work, although there still is no public API.

I also still don't quite understand how other methods work since the refactor, so this
only implements `sel`.

<details><summary>Usage, for anyone who wants to play around with it</summary>

``` python
import xarray as xr
from pint_xarray.index import PintMetaIndex

ds = xr.tutorial.open_dataset("air_temperature")
arr = ds.air

new_arr = xr.DataArray(
    arr.variable,
    coords={
        "lat": arr.lat.variable,
        "lon": arr.lon.variable,
        "time": arr.time.variable,
    },
    indexes={
        "lat": PintMetaIndex(arr.xindexes["lat"], {"lat": arr.lat.attrs.get("units")}),
        "lon": PintMetaIndex(arr.xindexes["lon"], {"lon": arr.lon.attrs.get("units")}),
        "time": arr.xindexes["time"],
    },
    fastpath=True,
)
new_arr.sel(
    lat=ureg.Quantity([75, 70, 65], "deg"),
    lon=ureg.Quantity([200, 202.5], "deg"),
)
```

This will fail at the moment because `xarray` seems to treat `dask`
arrays differently from `duck dask` arrays:

``` python
a = da.zeros((10, 10), chunks=(5, 5))
q = ureg.Quantity(a, "m")
arr1 = xr.DataArray(a, dims=("x", "y"))
arr2 = xr.DataArray(q, dims=("x", "y"))

arr1.isel(x=[0, 2, 4], y=[1, 3, 5])  # works
arr2.isel(x=[0, 2, 4], y=[1, 3, 5])  # fails
```
but passing single values works!

</details>

- [x] Closes #162
- [ ] Tests added
- [x] Passes `pre-commit run --all-files`
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [ ] New functions/methods are listed in `api.rst`