### PR TITLE
upstream compatibility

### DIFF
--- a/pint_xarray/accessors.py
+++ b/pint_xarray/accessors.py
@@ -2,8 +2,7 @@
 import itertools
 
 import pint
-from pint.quantity import Quantity
-from pint.unit import Unit
+from pint import Quantity, Unit
 from xarray import register_dataarray_accessor, register_dataset_accessor
 from xarray.core.dtypes import NA
 


### PR DESCRIPTION
Recent changes to `pint` changed the location of the `Quantity` and `Unit` classes. To fix that and avoid future issues, we can just import them from the top-level module.

- [x] Passes `pre-commit run --all-files`
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`