### PR TITLE
change `.pint.magnitude` to return a `DataArray`

### DIFF
--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -10,6 +10,8 @@ What's new
   By `Justus Magin <https://github.com/keewis>`_.
 - preserve :py:class:`pandas.MultiIndex` objects (:issue:`164`, :pull:`168`).
   By `Justus Magin <https://github.com/keewis>`_.
+- return a :py:class:`DataArray` from :py:attr:`DataArray.pint.magnitude` (:issue:`151`, :pull:`172`)
+  By `Justus Magin <https://github.com/keewis>`_.
 
 0.2.1 (26 Jul 2021)
 -------------------

--- a/pint_xarray/accessors.py
+++ b/pint_xarray/accessors.py
@@ -435,8 +435,7 @@ class PintDataArrayAccessor:
     @property
     def magnitude(self):
         """the magnitude of the data or the data itself if not a quantity."""
-        data = self.da.data
-        return getattr(data, "magnitude", data)
+        return self.dequantify()
 
     @property
     def units(self):

--- a/pint_xarray/tests/test_accessors.py
+++ b/pint_xarray/tests/test_accessors.py
@@ -191,11 +191,12 @@ class TestPropertiesDataArray:
     def test_magnitude_getattr(self, example_quantity_da):
         da = example_quantity_da
         actual = da.pint.magnitude
-        assert not isinstance(actual, Quantity)
+        assert isinstance(actual, xr.DataArray)
+        assert not isinstance(actual.data, Quantity)
 
     def test_magnitude_getattr_unitless(self, example_unitless_da):
         da = example_unitless_da
-        xr.testing.assert_duckarray_equal(da.pint.magnitude, da.data)
+        xr.testing.assert_identical(da.pint.magnitude, da)
 
     def test_units_getattr(self, example_quantity_da):
         da = example_quantity_da


### PR DESCRIPTION
At the moment, this is an alias of `.pint.dequantify()`, but it could just as well be something similar to:

``` python
dequantified = da.pint.dequantify()
dequantified.attrs.pop("units", None)
magnitude = dequantified.pint.quantify()
```

What do you think, @dcherian, @TomNicholas?

- [x] Closes #151
- [x] Tests added
- [x] Passes `pre-commit run --all-files`
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`