### PR TITLE
make sure re-quantifying dimension coordinates works

### DIFF
--- a/pint_xarray/accessors.py
+++ b/pint_xarray/accessors.py
@@ -142,7 +142,10 @@ def _decide_units(units, registry, unit_attribute):
     elif units is _default:
         if unit_attribute in no_unit_values:
             return unit_attribute
-        units = registry.parse_units(unit_attribute)
+        if isinstance(unit_attribute, Unit):
+            units = unit_attribute
+        else:
+            units = registry.parse_units(unit_attribute)
     else:
         units = registry.parse_units(units)
     return units

--- a/pint_xarray/accessors.py
+++ b/pint_xarray/accessors.py
@@ -363,6 +363,31 @@ class PintDataArrayAccessor:
         if invalid_units:
             raise ValueError(format_error_message(invalid_units, "parse"))
 
+        existing_units = {
+            name: unit
+            for name, unit in conversion.extract_units(self.da).items()
+            if isinstance(unit, Unit)
+        }
+        overwritten_units = {
+            name: (old, new)
+            for name, (old, new) in zip_mappings(
+                existing_units, new_units, fill_value=_default
+            ).items()
+            if old is not _default and new is not _default
+        }
+        if overwritten_units:
+            errors = {
+                name: (
+                    new,
+                    ValueError(
+                        f"Cannot attach unit {repr(new)} to quantity: data "
+                        f"already has units {repr(old)}"
+                    ),
+                )
+                for name, (old, new) in overwritten_units.items()
+            }
+            raise ValueError(format_error_message(errors, "attach"))
+
         return self.da.pipe(conversion.strip_unit_attributes).pipe(
             conversion.attach_units, new_units
         )
@@ -1052,6 +1077,31 @@ class PintDatasetAccessor:
 
         if invalid_units:
             raise ValueError(format_error_message(invalid_units, "parse"))
+
+        existing_units = {
+            name: unit
+            for name, unit in conversion.extract_units(self.ds).items()
+            if isinstance(unit, Unit)
+        }
+        overwritten_units = {
+            name: (old, new)
+            for name, (old, new) in zip_mappings(
+                existing_units, new_units, fill_value=_default
+            ).items()
+            if old is not _default and new is not _default
+        }
+        if overwritten_units:
+            errors = {
+                name: (
+                    new,
+                    ValueError(
+                        f"Cannot attach unit {repr(new)} to quantity: data "
+                        f"already has units {repr(old)}"
+                    ),
+                )
+                for name, (old, new) in overwritten_units.items()
+            }
+            raise ValueError(format_error_message(errors, "attach"))
 
         return self.ds.pipe(conversion.strip_unit_attributes).pipe(
             conversion.attach_units, new_units

--- a/pint_xarray/tests/test_accessors.py
+++ b/pint_xarray/tests/test_accessors.py
@@ -144,6 +144,13 @@ class TestQuantifyDataArray:
         q = arr.pint.quantify()
         assert isinstance(q.attrs["units"], Unit)
 
+    def test_dimension_coordinate_already_quantified(self):
+        ds = xr.Dataset(coords={"x": ("x", [10], {"units": unit_registry.Unit("m")})})
+        arr = ds.x
+
+        with pytest.raises(ValueError):
+            arr.pint.quantify({"x": "s"})
+
 
 @pytest.mark.parametrize("formatter", ("", "P", "C"))
 @pytest.mark.parametrize("modifier", ("", "~"))

--- a/pint_xarray/tests/test_accessors.py
+++ b/pint_xarray/tests/test_accessors.py
@@ -329,6 +329,20 @@ class TestQuantifyDataSet:
         with pytest.raises(ValueError, match="'users'"):
             ds.pint.quantify(units={"users": "aecjhbav"})
 
+    def test_existing_units(self, example_quantity_ds):
+        ds = example_quantity_ds.copy()
+        ds.t.attrs["units"] = unit_registry.Unit("m")
+
+        with pytest.raises(ValueError, match="Cannot attach"):
+            ds.pint.quantify({"funds": "kg"})
+
+    def test_existing_units_dimension(self, example_quantity_ds):
+        ds = example_quantity_ds.copy()
+        ds.t.attrs["units"] = unit_registry.Unit("m")
+
+        with pytest.raises(ValueError, match="Cannot attach"):
+            ds.pint.quantify({"t": "s"})
+
 
 class TestDequantifyDataSet:
     def test_strip_units(self, example_quantity_ds):

--- a/pint_xarray/tests/test_accessors.py
+++ b/pint_xarray/tests/test_accessors.py
@@ -135,6 +135,15 @@ class TestQuantifyDataArray:
         result = da.pint.quantify()
         assert result.pint.units == Unit("1 / meter")
 
+    def test_dimension_coordinate(self):
+        ds = xr.Dataset(coords={"x": ("x", [10], {"units": "m"})})
+        arr = ds.x
+
+        # does not actually quantify because `arr` wraps a IndexVariable
+        # but we still get a `Unit` in the attrs
+        q = arr.pint.quantify()
+        assert isinstance(q.attrs["units"], Unit)
+
 
 @pytest.mark.parametrize("formatter", ("", "P", "C"))
 @pytest.mark.parametrize("modifier", ("", "~"))


### PR DESCRIPTION
Now that we use `call_on_dataset` the call does not fail because of `xarray`, but because we pass a `Unit` object to `parse_units`.

I also tightened the restriction on dimension coordinates, as it was possible to change their units by quantifying. For #47 we might want to partially lift this restriction again.

- [x] Closes #105
- [x] Tests added
- [x] Passes `pre-commit run --all-files`
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`