### PR TITLE
use `.pint.quantify()` as a identity operator

### DIFF
--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -12,6 +12,8 @@ What's new
   By `Justus Magin <https://github.com/keewis>`_.
 - fix "quantifying" dimension coordinates (:issue:`105`, :pull:`174`).
   By `Justus Magin <https://github.com/keewis>`_.
+- allow using `.pint.quantify()` as a identity operator (:issue:`47`, :pull:`175`).
+  By `Justus Magin <https://github.com/keewis>`_.
 
 0.2.1 (26 Jul 2021)
 -------------------

--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -12,7 +12,8 @@ What's new
   By `Justus Magin <https://github.com/keewis>`_.
 - fix "quantifying" dimension coordinates (:issue:`105`, :pull:`174`).
   By `Justus Magin <https://github.com/keewis>`_.
-- allow using `.pint.quantify()` as a identity operator (:issue:`47`, :pull:`175`).
+- allow using :py:meth:`DataArray.pint.quantify` and :py:meth:`Dataset.pint.quantify`
+  as identity operators (:issue:`47`, :pull:`175`).
   By `Justus Magin <https://github.com/keewis>`_.
 
 0.2.1 (26 Jul 2021)

--- a/pint_xarray/accessors.py
+++ b/pint_xarray/accessors.py
@@ -123,7 +123,7 @@ def get_registry(unit_registry, new_units, existing_units):
 
 
 def _decide_units(units, registry, unit_attribute):
-    if units is _default and unit_attribute is _default:
+    if units is _default and unit_attribute in (None, _default):
         # or warn and return None?
         raise ValueError("no units given")
     elif units in no_unit_values or isinstance(units, Unit):
@@ -330,11 +330,11 @@ class PintDataArrayAccessor:
         new_units = {}
         invalid_units = {}
         for name, (unit, attr) in possible_new_units.items():
-            if unit is not _default or attr is not _default:
+            if unit not in (_default, None) or attr not in (_default, None):
                 try:
                     new_units[name] = _decide_units(unit, registry, attr)
                 except (ValueError, pint.UndefinedUnitError) as e:
-                    if unit is not _default:
+                    if unit not in (_default, None):
                         type = "parameter"
                         reported_unit = unit
                     else:

--- a/pint_xarray/accessors.py
+++ b/pint_xarray/accessors.py
@@ -1045,7 +1045,7 @@ class PintDatasetAccessor:
         new_units = {}
         invalid_units = {}
         for name, (unit, attr) in possible_new_units.items():
-            if unit is not _default or attr is not _default:
+            if unit is not _default or attr not in (None, _default):
                 try:
                     new_units[name] = _decide_units(unit, registry, attr)
                 except (ValueError, pint.UndefinedUnitError) as e:
@@ -1071,7 +1071,7 @@ class PintDatasetAccessor:
             for name, (old, new) in zip_mappings(
                 existing_units, new_units, fill_value=_default
             ).items()
-            if old is not _default and new is not _default
+            if old is not _default and new is not _default and old != new
         }
         if overwritten_units:
             errors = {

--- a/pint_xarray/accessors.py
+++ b/pint_xarray/accessors.py
@@ -356,7 +356,7 @@ class PintDataArrayAccessor:
             for name, (old, new) in zip_mappings(
                 existing_units, new_units, fill_value=_default
             ).items()
-            if old is not _default and new is not _default
+            if old is not _default and new is not _default and old != new
         }
         if overwritten_units:
             errors = {

--- a/pint_xarray/accessors.py
+++ b/pint_xarray/accessors.py
@@ -2,7 +2,7 @@
 import itertools
 
 import pint
-from pint import Quantity, Unit
+from pint import Unit
 from xarray import register_dataarray_accessor, register_dataset_accessor
 from xarray.core.dtypes import NA
 
@@ -321,13 +321,6 @@ class PintDataArrayAccessor:
         array([0.4, 0.9])
         Dimensions without coordinates: wavelength
         """
-
-        if isinstance(self.da.data, Quantity):
-            raise ValueError(
-                f"Cannot attach unit {units} to quantity: data "
-                f"already has units {self.da.data.units}"
-            )
-
         if units is None or isinstance(units, (str, pint.Unit)):
             if self.da.name in unit_kwargs:
                 raise ValueError(

--- a/pint_xarray/accessors.py
+++ b/pint_xarray/accessors.py
@@ -71,16 +71,6 @@ def zip_mappings(*mappings, fill_value=None):
     return zipped
 
 
-def merge_mappings(first, *mappings):
-    result = first.copy()
-    for mapping in mappings:
-        result.update(
-            {key: value for key, value in mapping.items() if value is not None}
-        )
-
-    return result
-
-
 def units_to_str_or_none(mapping, unit_format):
     formatter = str if not unit_format else lambda v: unit_format.format(v)
 
@@ -109,8 +99,8 @@ def either_dict_or_kwargs(positional, keywords, method_name):
 
 
 def get_registry(unit_registry, new_units, existing_units):
-    units = merge_mappings(existing_units, new_units)
-    registries = {unit._REGISTRY for unit in units.values() if isinstance(unit, Unit)}
+    units = itertools.chain(new_units.values(), existing_units.values())
+    registries = {unit._REGISTRY for unit in units if isinstance(unit, Unit)}
 
     if unit_registry is None:
         if not registries:

--- a/pint_xarray/conversion.py
+++ b/pint_xarray/conversion.py
@@ -33,6 +33,9 @@ def array_attach_units(data, unit):
         raise ValueError(f"cannot use {unit!r} as a unit")
 
     if isinstance(data, pint.Quantity):
+        if data.units == unit:
+            return data
+
         raise ValueError(
             f"Cannot attach unit {unit!r} to quantity: data "
             f"already has units {data.units}"

--- a/pint_xarray/tests/test_accessors.py
+++ b/pint_xarray/tests/test_accessors.py
@@ -118,15 +118,20 @@ class TestQuantifyDataArray:
     def test_attach_no_units(self):
         arr = xr.DataArray([1, 2, 3], dims="x")
         quantified = arr.pint.quantify()
-        assert_identical(arr, quantified)
+        assert_identical(quantified, arr)
+        assert_units_equal(quantified, arr)
 
     def test_attach_no_new_units(self):
         da = xr.DataArray(unit_registry.Quantity([1, 2, 3], "m"), dims="x")
-        assert_identical(da.pint.quantify(), da)
+        quantified = da.pint.quantify()
+        assert_identical(quantified, da)
+        assert_units_equal(quantified, da)
 
     def test_attach_same_units(self):
         da = xr.DataArray(unit_registry.Quantity([1, 2, 3], "m"), dims="x")
-        assert_identical(da.pint.quantify("m"), da)
+        quantified = da.pint.quantify("m")
+        assert_identical(quantified, da)
+        assert_units_equal(quantified, da)
 
     def test_error_when_changing_units_dimension_coordinates(self):
         arr = xr.DataArray(
@@ -157,7 +162,10 @@ class TestQuantifyDataArray:
         ds = xr.Dataset(coords={"x": ("x", [10], {"units": unit_registry.Unit("m")})})
         arr = ds.x
 
-        assert_identical(arr.pint.quantify({"x": "m"}), arr)
+        quantified = arr.pint.quantify({"x": "m"})
+
+        assert_identical(quantified, arr)
+        assert_units_equal(quantified, arr)
 
     def test_error_on_nonsense_units(self, example_unitless_da):
         da = example_unitless_da
@@ -341,15 +349,22 @@ class TestQuantifyDataSet:
     def test_attach_no_units(self):
         ds = xr.Dataset({"a": ("x", [1, 2, 3])})
         quantified = ds.pint.quantify()
-        assert_identical(ds, quantified)
+        assert_identical(quantified, ds)
+        assert_units_equal(quantified, ds)
 
     def test_attach_no_new_units(self):
         ds = xr.Dataset({"a": ("x", unit_registry.Quantity([1, 2, 3], "m"))})
-        assert_identical(ds.pint.quantify(), ds)
+        quantified = ds.pint.quantify()
+
+        assert_identical(quantified, ds)
+        assert_units_equal(quantified, ds)
 
     def test_attach_same_units(self):
         ds = xr.Dataset({"a": ("x", unit_registry.Quantity([1, 2, 3], "m"))})
-        assert_identical(ds.pint.quantify({"a": "m"}), ds)
+        quantified = ds.pint.quantify({"a": "m"})
+
+        assert_identical(quantified, ds)
+        assert_units_equal(quantified, ds)
 
     def test_error_when_changing_units_dimension_coordinates(self):
         ds = xr.Dataset(

--- a/pint_xarray/tests/test_conversion.py
+++ b/pint_xarray/tests/test_conversion.py
@@ -78,6 +78,20 @@ class TestArrayFunctions:
                 "already has units",
                 id="unit object on quantity",
             ),
+            pytest.param(
+                Unit("m"),
+                Quantity(np.array([0, 1]), "m"),
+                Quantity(np.array([0, 1]), "m"),
+                None,
+                id="unit object on quantity with same unit",
+            ),
+            pytest.param(
+                Unit("mm"),
+                Quantity(np.array([0, 1]), "m"),
+                None,
+                "already has units",
+                id="unit object on quantity with similar unit",
+            ),
         ),
     )
     def test_array_attach_units(self, data, unit, expected, match):


### PR DESCRIPTION
Building on #174, this allows quantifying without any units involved at all, requantifying without new units, or requantifying quantified variables with the same units (they have to match exactly):

```python
In [1]: import xarray as xr
   ...: import pint_xarray

In [2]: ds = xr.Dataset({"a": ("x", [1, 2, 3, 4], {"units": "m"})})
   ...: q = ds.pint.quantify()
   ...: q
Out[2]: 
<xarray.Dataset>
Dimensions:  (x: 4)
Dimensions without coordinates: x
Data variables:
    a        (x) int64 [m] 1 2 3 4

In [3]: q.pint.quantify()
Out[3]: 
<xarray.Dataset>
Dimensions:  (x: 4)
Dimensions without coordinates: x
Data variables:
    a        (x) int64 [m] 1 2 3 4

In [4]: q.pint.quantify({"a": "m"})
Out[4]: 
<xarray.Dataset>
Dimensions:  (x: 4)
Dimensions without coordinates: x
Data variables:
    a        (x) int64 [m] 1 2 3 4

In [5]: q.pint.quantify({"a": "s"})
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
Input In [5], in <cell line: 1>()
----> 1 q.pint.quantify({"a": "s"})

File .../pint_xarray/accessors.py:1087, in PintDatasetAccessor.quantify(self, units, unit_registry, **unit_kwargs)
   1076 if overwritten_units:
   1077     errors = {
   1078         name: (
   1079             new,
   (...)
   1085         for name, (old, new) in overwritten_units.items()
   1086     }
-> 1087     raise ValueError(format_error_message(errors, "attach"))
   1089 return self.ds.pipe(conversion.strip_unit_attributes).pipe(
   1090     conversion.attach_units, new_units
   1091 )

ValueError: Cannot attach units:
    cannot attach units to variable 'a': second (reason: Cannot attach unit <Unit('second')> to quantity: data already has units <Unit('meter')>)

In [6]: q.pint.quantify({"a": "mm"})
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
Input In [6], in <cell line: 1>()
----> 1 q.pint.quantify({"a": "mm"})

File ~/repos/pint-xarray/pint_xarray/accessors.py:1087, in PintDatasetAccessor.quantify(self, units, unit_registry, **unit_kwargs)
   1076 if overwritten_units:
   1077     errors = {
   1078         name: (
   1079             new,
   (...)
   1085         for name, (old, new) in overwritten_units.items()
   1086     }
-> 1087     raise ValueError(format_error_message(errors, "attach"))
   1089 return self.ds.pipe(conversion.strip_unit_attributes).pipe(
   1090     conversion.attach_units, new_units
   1091 )

ValueError: Cannot attach units:
    cannot attach units to variable 'a': millimeter (reason: Cannot attach unit <Unit('millimeter')> to quantity: data already has units <Unit('meter')>)
```

- [x] Closes #47
- [x] Tests added
- [x] Passes `pre-commit run --all-files`
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`

cc @lukelbd