### PR TITLE
clean up the documentation

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -75,8 +75,8 @@ html_theme = "sphinx_rtd_theme"
 
 # extlinks
 extlinks = {
-    "issue": (f"{github_url}/issues/%s", "GH"),
-    "pull": (f"{github_url}/pull/%s", "PR"),
+    "issue": (f"{github_url}/issues/%s", "GH%s"),
+    "pull": (f"{github_url}/pull/%s", "PR%s"),
 }
 
 # autosummary

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -14,5 +14,5 @@ In order to keep code consistent, we use
 
 - `Black <https://black.readthedocs.io/en/stable/>`_ for standardized code formatting
 - `blackdoc <https://blackdoc.readthedocs.io/en/stable/>`_ for standardized code formatting in documentation
-- `Flake8 <http://flake8.pycqa.org/en/latest/>`_ for general code quality
-- `isort <https://github.com/timothycrosley/isort>`_ for standardized order in imports. See also `flake8-isort <https://github.com/gforcada/flake8-isort>`_.
+- `Flake8 <https://flake8.pycqa.org/en/latest/>`_ for general code quality
+- `isort <https://github.com/PyCQA/isort>`_ for standardized order in imports. See also `flake8-isort <https://github.com/gforcada/flake8-isort>`_.

--- a/docs/creation.rst
+++ b/docs/creation.rst
@@ -130,6 +130,6 @@ This will get the string representation of a :py:class:`pint.Unit` instance and
 attach it as a ``units`` attribute. The data of the variable will now be
 whatever `pint`_ wrapped.
 
-.. _pint: https://pint.readthedocs.org/en/stable
-.. _xarray: https://xarray.pydata.org/en/stable
+.. _pint: https://pint.readthedocs.io/en/stable/
+.. _xarray: https://docs.xarray.dev/en/stable/
 .. _units in indexes: https://github.com/pydata/xarray/issues/1603

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,7 +4,6 @@ pooch
 netCDF4
 cf-xarray>=0.6
 sphinx<4
-ipython_genutils  # remove once there's a new `nbconvert` release
 sphinx_rtd_theme
 ipython
 ipykernel

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,7 +3,7 @@ xarray>=0.16.0
 pooch
 netCDF4
 cf-xarray>=0.6
-sphinx<4
+sphinx
 sphinx_rtd_theme
 ipython
 ipykernel

--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -35,10 +35,10 @@ What's new
 -----------------
 - rewrite :py:meth:`Dataset.pint.quantify` and :py:meth:`DataArray.pint.quantify`, to
   use pint's ``UnitRegistry.parse_units`` instead of ``UnitRegistry.parse_expression``
-  (:pull:`40`)
+  (:issue:`40`)
   By `Tom Nicholas <https://github.com/TomNicholas>`_.
 - ensure the variables which causes the error is explicit if an error occurs in
-  :py:meth:`Dataset.pint.quantify` and other methods (:pull:`43`, :pull:`91`)
+  :py:meth:`Dataset.pint.quantify` and other methods (:pull:`43`, :issue:`91`)
   By `Tom Nicholas <https://github.com/TomNicholas>`_ and `Justus Magin <https://github.com/keewis>`_.
 - refactor the internal conversion functions (:pull:`56`)
   By `Justus Magin <https://github.com/keewis>`_.

--- a/pint_xarray/accessors.py
+++ b/pint_xarray/accessors.py
@@ -970,7 +970,7 @@ class PintDatasetAccessor:
         units are specified then the units will be parsed from the
         ``"units"`` entry of the Dataset variable's ``.attrs``. Will
         raise a ValueError if any of the variables already contain a
-        unit-aware array.
+        unit-aware array with a different unit.
 
         .. note::
             Be aware that unless you're using ``dask`` this will load
@@ -1047,6 +1047,28 @@ class PintDatasetAccessor:
         Data variables:
             a        (x) int64 0 3 2
             b        (x) int64 5 -2 1
+
+        Quantify with the same unit:
+
+        >>> q = ds.pint.quantify()
+        >>> q
+        <xarray.Dataset>
+        Dimensions:  (x: 3)
+        Coordinates:
+          * x        (x) int64 0 1 2
+            u        (x) int64 [s] -1 0 1
+        Data variables:
+            a        (x) int64 [m] 0 3 2
+            b        (x) int64 5 -2 1
+        >>> q.pint.quantify({"a": "m"})
+        <xarray.Dataset>
+        Dimensions:  (x: 3)
+        Coordinates:
+          * x        (x) int64 0 1 2
+            u        (x) int64 [s] -1 0 1
+        Data variables:
+            a        (x) int64 [m] 0 3 2
+            b        (x) int64 5 -2 1
         """
         units = either_dict_or_kwargs(units, unit_kwargs, "quantify")
         registry = get_registry(unit_registry, units, conversion.extract_units(self.ds))
@@ -1112,8 +1134,8 @@ class PintDatasetAccessor:
         Parameters
         ----------
         format : str, default: None
-            The format specification (as accepted by pint) used for the string
-            representations. If ``None``, the registry's default
+            The format specification (as accepted by pint's unit formatter) used for the
+            string representations. If ``None``, the registry's default
             (:py:attr:`pint.UnitRegistry.default_format`) is used instead.
 
         Returns

--- a/pint_xarray/accessors.py
+++ b/pint_xarray/accessors.py
@@ -409,7 +409,8 @@ class PintDataArrayAccessor:
 
         See Also
         --------
-        https://pint.readthedocs.io/en/stable/tutorial.html#string-formatting
+        :doc:`pint:formatting`
+            pint's string formatting guide
 
         Examples
         --------
@@ -1146,7 +1147,8 @@ class PintDatasetAccessor:
 
         See Also
         --------
-        https://pint.readthedocs.io/en/stable/tutorial.html#string-formatting
+        :doc:`pint:formatting`
+            pint's string formatting guide
 
         Examples
         --------

--- a/pint_xarray/accessors.py
+++ b/pint_xarray/accessors.py
@@ -245,7 +245,7 @@ class PintDataArrayAccessor:
         parsed by the given unit registry. If no units are specified then the
         units will be parsed from the `'units'` entry of the DataArray's
         `.attrs`. Will raise a ValueError if the DataArray already contains a
-        unit-aware array.
+        unit-aware array with a different unit.
 
         .. note::
             Be aware that unless you're using ``dask`` this will load
@@ -309,6 +309,18 @@ class PintDataArrayAccessor:
         >>> da.pint.quantify(units=None)
         <xarray.DataArray (wavelength: 2)>
         array([0.4, 0.9])
+        Dimensions without coordinates: wavelength
+
+        Quantify with the same unit:
+
+        >>> q = da.pint.quantify()
+        >>> q
+        <xarray.DataArray (wavelength: 2)>
+        <Quantity([0.4 0.9], 'hertz')>
+        Dimensions without coordinates: wavelength
+        >>> q.pint.quantify("Hz")
+        <xarray.DataArray (wavelength: 2)>
+        <Quantity([0.4 0.9], 'hertz')>
         Dimensions without coordinates: wavelength
         """
         if units is None or isinstance(units, (str, pint.Unit)):


### PR DESCRIPTION
Over the last few month the documentation became slightly out-of-date, accumulating some broken links, incomplete docstrings, and other errors.

- [x] Passes `pre-commit run --all-files`