### PR TITLE
fix the documentation index page

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,9 +1,9 @@
 version: 2
 
 build:
-  os: ubuntu-20.04
+  os: ubuntu-22.04
   tools:
-    python: "3.9"
+    python: "3.10"
 
 python:
   install:

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,7 +4,7 @@ pooch
 netCDF4
 cf-xarray>=0.6
 sphinx
-sphinx_rtd_theme
+sphinx_rtd_theme>=1.0
 ipython
 ipykernel
 jupyter_client


### PR DESCRIPTION
With the upgrade to `sphinx>=5.0` the index page broke. As it turns out, this is a incompatibility with `sphinx_rtd_theme<0.5`, which is what RTD installs by default. Pinning `sphinx_rtd_theme` fixes that issue.