### PR TITLE
update outdated references in the documentation

### DIFF
--- a/pint_xarray/accessors.py
+++ b/pint_xarray/accessors.py
@@ -409,7 +409,7 @@ class PintDataArrayAccessor:
 
         See Also
         --------
-        :doc:`pint:formatting`
+        :doc:`pint:user/formatting`
             pint's string formatting guide
 
         Examples
@@ -1147,7 +1147,7 @@ class PintDatasetAccessor:
 
         See Also
         --------
-        :doc:`pint:formatting`
+        :doc:`pint:user/formatting`
             pint's string formatting guide
 
         Examples


### PR DESCRIPTION
`pint` recently restructured their documentation, which is a good thing: The new structure is much easier to navigate. However, this also means that some references broke.

- [x] Passes `pre-commit run --all-files`
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`