### PR TITLE
enable `dependabot`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
In order to keep the ci updated, this enables `dependabot` for github actions.

- [x] Passes `pre-commit run --all-files`