### PR TITLE
restructure the nightly CI

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -25,7 +25,7 @@ jobs:
     - uses: actions/checkout@v3
       with:
         fetch-depth: 2
-    - uses: keewis/ci-trigger@v1.1
+    - uses: xarray-contrib/ci-trigger@v1.2
       id: detect-trigger
       with:
         keyword: "[test-upstream]"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -82,110 +82,16 @@ jobs:
       run: python -m pip list
 
     - name: run tests
+      if: success()
       id: status
       run: |
-        set -euo pipefail
-        python -m pytest -rf --report-log output-${{ matrix.python-version }}-log.jsonl || (
-            echo '::set-output name=ARTIFACTS_AVAILABLE::true' && false
-        )
+        python -m pytest -rf --report-log=pytest-log.jsonl
 
-    - name: Upload artifacts
+    - name: report failures
       if: |
         failure()
-        && steps.status.outcome == 'failure'
+        && steps.tests.outcome == 'failure'
         && github.event_name == 'schedule'
-      uses: actions/upload-artifact@v3
+      uses: xarray-contrib/issue-from-pytest-log@v1
       with:
-        name: output-${{ matrix.python-version }}-log.jsonl
-        path: output-${{ matrix.python-version }}-log.jsonl
-        retention-days: 5
-
-  report:
-    name: Report
-    runs-on: ubuntu-latest
-    needs: upstream-dev
-    if: |
-      always()
-      && github.event_name == 'schedule'
-      && github.repository == 'xarray-contrib/pint-xarray'
-      && needs.upstream-dev.outputs.artifacts_availability == 'true'
-    steps:
-    - name: checkout the repository
-      uses: actions/checkout@v3
-
-    - name: setup python
-      uses: actions/setup-python@v3
-      with:
-        python-version: "3.x"
-
-    - name: setup environment
-      run: |
-        python -m pip install --upgrade pip
-        python -m pip install pytest
-
-    - uses: actions/download-artifact@v3
-      with:
-        path: /tmp/workspace/logs
-
-    - name: Move all log files into a single directory
-      run: |
-        rsync -a /tmp/workspace/logs/output-*/ ./logs
-        ls -R ./logs
-
-    - name: Parse logs
-      run: |
-        shopt -s globstar
-        python .github/workflows/parse_logs.py logs/**/*-log.jsonl
-
-    - name: Report failures
-      uses: actions/github-script@v6
-      with:
-        github-token: ${{ secrets.GITHUB_TOKEN }}
-        script: |
-            const fs = require('fs');
-            const pytest_logs = fs.readFileSync('pytest-logs.txt', 'utf8');
-            const title = "⚠️ Nightly upstream-dev CI failed ⚠️"
-            const workflow_url = `https://github.com/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`
-            const issue_body = `[Workflow Run URL](${workflow_url})\n${pytest_logs}`
-
-            // Run GraphQL query against GitHub API to find the most recent open issue used for reporting failures
-            const query = `query($owner:String!, $name:String!, $creator:String!, $label:String!){
-              repository(owner: $owner, name: $name) {
-                issues(first: 1, states: OPEN, filterBy: {createdBy: $creator, labels: [$label]}, orderBy: {field: CREATED_AT, direction: DESC}) {
-                  edges {
-                    node {
-                      body
-                      id
-                      number
-                    }
-                  }
-                }
-              }
-            }`;
-
-            const variables = {
-                owner: context.repo.owner,
-                name: context.repo.repo,
-                label: 'CI',
-                creator: "github-actions[bot]"
-            }
-            const result = await github.graphql(query, variables)
-
-            // If no issue is open, create a new issue,
-            // else update the body of the existing issue.
-            if (result.repository.issues.edges.length === 0) {
-                github.rest.issues.create({
-                    owner: variables.owner,
-                    repo: variables.name,
-                    body: issue_body,
-                    title: title,
-                    labels: [variables.label]
-                })
-            } else {
-                github.rest.issues.update({
-                    owner: variables.owner,
-                    repo: variables.name,
-                    issue_number: result.repository.issues.edges[0].node.number,
-                    body: issue_body
-                })
-            }
+        log-path: pytest-log.jsonl

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -60,7 +60,7 @@ jobs:
         fetch-depth: 0  # fetch all branches and tags
 
     - name: setup python
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
 


### PR DESCRIPTION
Just like `xarray` (and a lot of other repositories), this changes the internals of the nightly CI to use a dedicated action instead of custom github script to report failures.

- [x] Passes `pre-commit run --all-files`