### PR TITLE
manually update CI

### DIFF
--- a/.github/workflows/ci-additional.yml
+++ b/.github/workflows/ci-additional.yml
@@ -21,7 +21,7 @@ jobs:
     - name: checkout
       uses: actions/checkout@v3
     - name: setup python
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: "3.10"
     - name: initialize cache

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
           pip-
 
     - name: setup python
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     - uses: actions/checkout@v3
       with:
         fetch-depth: 2
-    - uses: keewis/ci-trigger@v1.1
+    - uses: xarray-contrib/ci-trigger@v1.1
       id: detect-trigger
       with:
         keyword: "[skip-ci]"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     - uses: actions/checkout@v3
       with:
         fetch-depth: 2
-    - uses: xarray-contrib/ci-trigger@v1.1
+    - uses: xarray-contrib/ci-trigger@v1
       id: detect-trigger
       with:
         keyword: "[skip-ci]"


### PR DESCRIPTION
Outdated actions:
- `ci-trigger`
- `setup-python`

My guess is that dependabot just didn't run on those files yet.