### PR TITLE
Add test against pint master and pint pre

### DIFF
--- a/.github/workflows/ci-pint-master.yml
+++ b/.github/workflows/ci-pint-master.yml
@@ -1,0 +1,94 @@
+# adapted from xarray's ci
+name: CI-pint-master
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  detect-skip-ci-trigger:
+    name: "Detect CI Trigger: [skip-ci]"
+    if: github.event_name == 'push' || github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    outputs:
+      triggered: ${{ steps.detect-trigger.outputs.trigger-found }}
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 2
+    - uses: xarray-contrib/ci-trigger@v1
+      id: detect-trigger
+      with:
+        keyword: "[skip-ci]"
+
+  ci:
+    name: ${{ matrix.os }} py${{ matrix.python-version }}
+    runs-on: ${{ matrix.os }}
+    needs: detect-skip-ci-trigger
+
+    if: |
+      always()
+      && github.repository == 'xarray-contrib/pint-xarray'
+      && (
+        github.event_name == 'workflow_dispatch'
+        || needs.detect-skip-ci-trigger.outputs.triggered == 'false'
+      )
+
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.8", "3.9", "3.10"]
+        os: ["ubuntu-latest", "macos-latest", "windows-latest"]
+
+    steps:
+    - name: checkout the repository
+      uses: actions/checkout@v3
+      with:
+        # need to fetch all tags to get a correct version
+        fetch-depth: 0  # fetch all branches and tags
+
+    - name: cache pip
+      uses: actions/cache@v3
+      with:
+        path: ~/.cache/pip
+        key: pip-py${{ matrix.python-version }}
+        restore-keys: |
+          pip-
+
+    - name: setup python
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: upgrade pip
+      run: python -m pip install --upgrade pip setuptools wheel
+
+    - name: Install pint master
+      run: python -m pip install git+https://github.com/hgrecco/pint.git@master
+
+    - name: install dependencies
+      run: |
+        python -m pip install -r ci/requirements.txt
+
+    - name: install pint-xarray
+      run: python -m pip install --no-deps .
+
+    - name: show versions
+      run: python -m pip list
+
+    - name: import pint-xarray
+      run: |
+        python -c 'import pint_xarray'
+
+    - name: run tests
+      if: success()
+      id: status
+      run: |
+        python -m pytest --cov=pint_xarray --cov-report=xml

--- a/.github/workflows/ci-pint-pre.yml
+++ b/.github/workflows/ci-pint-pre.yml
@@ -1,0 +1,94 @@
+# adapted from xarray's ci
+name: CI-pint-pre
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  detect-skip-ci-trigger:
+    name: "Detect CI Trigger: [skip-ci]"
+    if: github.event_name == 'push' || github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    outputs:
+      triggered: ${{ steps.detect-trigger.outputs.trigger-found }}
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 2
+    - uses: xarray-contrib/ci-trigger@v1
+      id: detect-trigger
+      with:
+        keyword: "[skip-ci]"
+
+  ci:
+    name: ${{ matrix.os }} py${{ matrix.python-version }}
+    runs-on: ${{ matrix.os }}
+    needs: detect-skip-ci-trigger
+
+    if: |
+      always()
+      && github.repository == 'xarray-contrib/pint-xarray'
+      && (
+        github.event_name == 'workflow_dispatch'
+        || needs.detect-skip-ci-trigger.outputs.triggered == 'false'
+      )
+
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.8", "3.9", "3.10"]
+        os: ["ubuntu-latest", "macos-latest", "windows-latest"]
+
+    steps:
+    - name: checkout the repository
+      uses: actions/checkout@v3
+      with:
+        # need to fetch all tags to get a correct version
+        fetch-depth: 0  # fetch all branches and tags
+
+    - name: cache pip
+      uses: actions/cache@v3
+      with:
+        path: ~/.cache/pip
+        key: pip-py${{ matrix.python-version }}
+        restore-keys: |
+          pip-
+
+    - name: setup python
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: upgrade pip
+      run: python -m pip install --upgrade pip setuptools wheel
+
+    - name: Install pint pre
+      run: python -m pip install --pre pint
+
+    - name: install dependencies
+      run: |
+        python -m pip install -r ci/requirements.txt
+
+    - name: install pint-xarray
+      run: python -m pip install --no-deps .
+
+    - name: show versions
+      run: python -m pip list
+
+    - name: import pint-xarray
+      run: |
+        python -c 'import pint_xarray'
+
+    - name: run tests
+      if: success()
+      id: status
+      run: |
+        python -m pytest --cov=pint_xarray --cov-report=xml


### PR DESCRIPTION
Copied from CI.yml but removing coveralls

The plan is to add their status to https://github.com/hgrecco/pint/blob/master/downstream_status.md

<!-- Feel free to remove check-list items aren't relevant to your change -->

- [ ] Closes #xxxx
- [ ] Tests added
- [ ] Passes `pre-commit run --all-files`
- [ ] User visible changes (including notable bug fixes) are documented in `whats-new.rst`
- [ ] New functions/methods are listed in `api.rst`
