### PR TITLE
ignore datetime units

### DIFF
--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -5,7 +5,6 @@ What's new
 0.4 (*unreleased*)
 ------------------
 - adopt `SPEC0 <https://scientific-python.org/specs/spec-0000>`_ (:pull:`228`)
-  By `Justus Magin <https://github.com/keewis>`_.
 
   This means that the supported versions change:
 
@@ -18,7 +17,10 @@ What's new
    pint                0.16             0.19
   ============ ==============  ==============
 
+  By `Justus Magin <https://github.com/keewis>`_.
 - add support for python 3.11 (:pull:`228`)
+  By `Justus Magin <https://github.com/keewis>`_.
+- ignore datetime units on attributes (:pull:`241`)
   By `Justus Magin <https://github.com/keewis>`_.
 
 0.3 (27 Jul 2022)

--- a/pint_xarray/accessors.py
+++ b/pint_xarray/accessors.py
@@ -258,6 +258,12 @@ class PintDataArrayAccessor:
             ``xarray`` changes the way it implements indexes, these
             units will be set as attributes.
 
+        .. note::
+            Also note that datetime units (i.e. ones that match
+            ``{units} since {date}``) in unit attributes will be
+            ignored, to avoid interfering with ``xarray``'s datetime
+            encoding / decoding.
+
         Parameters
         ----------
         units : unit-like or mapping of hashable to unit-like, optional
@@ -983,6 +989,12 @@ class PintDatasetAccessor:
             As units in dimension coordinates are not supported until
             ``xarray`` changes the way it implements indexes, these
             units will be set as attributes.
+
+        .. note::
+            Also note that datetime units (i.e. ones that match
+            ``{units} since {date}``) in unit attributes will be
+            ignored, to avoid interfering with ``xarray``'s datetime
+            encoding / decoding.
 
         Parameters
         ----------

--- a/pint_xarray/conversion.py
+++ b/pint_xarray/conversion.py
@@ -275,7 +275,11 @@ def extract_units(obj):
 
 
 def extract_unit_attributes_dataset(obj, attr="units"):
-    return {name: var.attrs.get(attr, None) for name, var in obj.variables.items()}
+    all_units = {name: var.attrs.get(attr, None) for name, var in obj.variables.items()}
+
+    return {
+        name: unit for name, unit in all_units.items() if not is_datetime_unit(unit)
+    }
 
 
 def extract_unit_attributes(obj, attr="units"):

--- a/pint_xarray/conversion.py
+++ b/pint_xarray/conversion.py
@@ -321,6 +321,9 @@ def strip_units(obj):
 def strip_unit_attributes_dataset(obj, attr="units"):
     new_obj = obj.copy()
     for var in new_obj.variables.values():
+        if is_datetime_unit(var.attrs.get(attr, "")):
+            continue
+
         var.attrs.pop(attr, None)
 
     return new_obj

--- a/pint_xarray/conversion.py
+++ b/pint_xarray/conversion.py
@@ -18,7 +18,7 @@ datetime_units_re = re.compile(rf"{time_units_re} since {datetime_re}")
 
 
 def is_datetime_unit(unit):
-    return datetime_units_re.match(unit) is not None
+    return isinstance(unit, str) and datetime_units_re.match(unit) is not None
 
 
 def array_attach_units(data, unit):

--- a/pint_xarray/conversion.py
+++ b/pint_xarray/conversion.py
@@ -1,4 +1,5 @@
 import itertools
+import re
 
 import pint
 from xarray import DataArray, Dataset, IndexVariable, Variable
@@ -10,6 +11,14 @@ no_unit_values = ("none", None)
 unit_attribute_name = "units"
 slice_attributes = ("start", "stop", "step")
 temporary_name = "<this-array>"
+
+time_units_re = r"\w+"
+datetime_re = r"\d{4}-\d{2}-\d{2}(?:[ T]\d{2}:\d{2}:\d{2}(?:\.\d+)?)?"
+datetime_units_re = re.compile(rf"{time_units_re} since {datetime_re}")
+
+
+def is_datetime_unit(unit):
+    return datetime_units_re.match(unit) is not None
 
 
 def array_attach_units(data, unit):

--- a/pint_xarray/tests/test_conversion.py
+++ b/pint_xarray/tests/test_conversion.py
@@ -482,6 +482,11 @@ class TestXarrayFunctions:
                 {"a": "K", "b": "hPa", "x": "m", "u": "s"},
                 id="Dataset",
             ),
+            pytest.param(
+                Dataset(coords={"t": ("t", [], {"units": "seconds since 2000-01-01"})}),
+                {},
+                id="datetime_unit",
+            ),
         ),
     )
     def test_extract_unit_attributes(self, obj, expected):
@@ -545,6 +550,11 @@ class TestXarrayFunctions:
                 ),
                 {"a": "K", "b": "hPa", "x": "m", "u": "s"},
                 id="Dataset",
+            ),
+            pytest.param(
+                Dataset(coords={"t": ("t", [], {"units": "seconds since 2000-01-01"})}),
+                {},
+                id="datetime_unit",
             ),
         ),
     )


### PR DESCRIPTION
The cf conventions use units that follow the structure of `{time_units} since {date}` to encode calendar dates to numeric arrays (integers / floats). When `xarray`decodes datasets, it uses these datetime units to convert the numeric arrays to datetime arrays (and the other way around when encoding).

However, these datetime units can still be on variables, for example if a user sets `decode_times=False`. In that case, we would pick up those units and try to parse them, only to fail immediately because `pint` cannot understand them (nor should it).

This PR makes `extract_unit_attributes` and `strip_unit_attributes` skip any of these units, making it seem as if the `units` attribute didn't exist / was `None` (the attribute will still be there, though).

cc @jbusecke, @TomNicholas, @dcherian

- [x] Closes jbusecke/xMIP#279, closes jbusecke/xMIP#322
- [x] Tests added
- [x] Passes `pre-commit run --all-files`
- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`