### PR TITLE
drop python 3.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11", "3.12"]
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
 
     steps:
@@ -79,10 +79,6 @@ jobs:
     - name: install dependencies
       run: |
         python -m pip install -r ci/requirements.txt
-        if [[ "${{matrix.python-version}}" == "3.9" ]]; then
-            # remove after the release
-            python -m pip install 'numpy<2.0'
-        fi
 
     - name: install pint-xarray
       run: python -m pip install --no-deps .

--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -4,7 +4,8 @@ What's new
 ==========
 0.5 (*unreleased*)
 ------------------
-
+- drop support for python 3.9 (:pull:``)
+  By `Justus Magin <https://github.com/keewis>`_.
 
 0.4 (23 Jun 2024)
 -----------------

--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -4,7 +4,7 @@ What's new
 ==========
 0.5 (*unreleased*)
 ------------------
-- drop support for python 3.9 (:pull:``)
+- drop support for python 3.9 (:pull:`266`)
   By `Justus Magin <https://github.com/keewis>`_.
 
 0.4 (23 Jun 2024)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,13 +13,12 @@ classifiers = [
     "License :: OSI Approved :: Apache Software License",
     "Operating System :: OS Independent",
     "Programming Language :: Python",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Topic :: Scientific/Engineering",
 ]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dependencies = [
     "numpy >= 1.23",
     "xarray >= 2022.06.0",


### PR DESCRIPTION
According to SPEC0, we're allowed to drop python 3.9

- [x] User visible changes (including notable bug fixes) are documented in `whats-new.rst`