### PR TITLE
release 0.5

### DIFF
--- a/docs/whats-new.rst
+++ b/docs/whats-new.rst
@@ -2,7 +2,7 @@
 
 What's new
 ==========
-0.5 (*unreleased*)
+0.5 (09 Jun 2025)
 ------------------
 - drop support for python 3.9 (:pull:`266`)
   By `Justus Magin <https://github.com/keewis>`_.


### PR DESCRIPTION
This release brings a few bug fixes, drops support for python 3.9, and most importantly includes a implementation for a `PintIndex`, which allows supporting `pint` arrays on indexed coordinates (most notably, dimension coordinates).

The `PintIndex` did not see as much use and testing as I would like, making this a breaking change.