### PR TITLE
don't lock or freeze nightly CI

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -8,7 +8,6 @@ on:
     branches: [main]
   schedule:
     - cron: "0 0 * * *" # Daily "At 00:00" UTC
-
   workflow_dispatch:
 
 concurrency:
@@ -63,12 +62,17 @@ jobs:
           # need to fetch all tags to get a correct version
           fetch-depth: 0 # fetch all branches and tags
 
+      - name: remove lockfile
+        run: |
+          rm pixi.lock
+
       - name: setup environment
         uses: prefix-dev/setup-pixi@fef5c9568ca6c4ff7707bf840ab0692ba3f08293 # 0.9.0
         with:
           environments: "nightly"
           locked: false
           frozen: false
+          cache: false
 
       - name: import pint-xarray
         run: |


### PR DESCRIPTION
The presence of a lock file apparently caused `pixi` to install with `--locked`, which is not suitable for nightly.