### PR TITLE
install the build frontend from the right pypi package

### DIFF
--- a/.github/workflows/pypi.yaml
+++ b/.github/workflows/pypi.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install python-build twine
+          python -m pip install build twine
 
       - name: Build tarball and wheels
         run: |


### PR DESCRIPTION
Looks like `python-build` on PyPI is something very different from the one on `conda-forge`. The correct name on PyPI is simply `build`.